### PR TITLE
feat: Policy engine and CRUD API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/supertest": "^7.2.0",
         "eslint": "^10.2.0",
         "eslint-config-prettier": "^10.1.8",
+        "msw": "^2.12.14",
         "prettier": "^3.8.1",
         "prisma": "^7.6.0",
         "supertest": "^7.2.2",
@@ -761,6 +762,94 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@ioredis/commands": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
@@ -780,6 +869,24 @@
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.3",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
+      "integrity": "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.2",
@@ -812,6 +919,31 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
       "version": "0.122.0",
@@ -1642,6 +1774,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/superagent": {
       "version": "8.1.9",
       "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
@@ -2062,6 +2201,32 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -2285,6 +2450,49 @@
         "consola": "^3.2.3"
       }
     },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
@@ -2293,6 +2501,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -2551,6 +2779,13 @@
         "fast-check": "^3.23.1"
       }
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/empathic": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
@@ -2676,6 +2911,16 @@
         "@esbuild/win32-arm64": "0.27.7",
         "@esbuild/win32-ia32": "0.27.7",
         "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -3253,6 +3498,16 @@
         "is-property": "^1.0.2"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -3374,6 +3629,16 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/graphql": {
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -3413,6 +3678,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hono": {
       "version": "4.12.10",
@@ -3536,6 +3808,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3548,6 +3830,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
@@ -4046,6 +4335,82 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.12.14",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.12.14.tgz",
+      "integrity": "sha512-4KXa4nVBIBjbDbd7vfQNuQ25eFxug0aropCQFoI0JdOBuJWamkT1yLVIWReFI8SiTRc+H1hKzaNk+cLk2N9rtQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/confirm": "^5.0.0",
+        "@mswjs/interceptors": "^0.41.2",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.0.2",
+        "graphql": "^16.12.0",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.10.1",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.0",
+        "type-fest": "^5.2.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/msw/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/mysql2": {
       "version": "3.15.3",
       "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.15.3.tgz",
@@ -4215,6 +4580,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -4752,6 +5124,16 @@
         "url": "https://github.com/sponsors/remeda"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -4781,6 +5163,13 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/rettime": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.10.1.tgz",
+      "integrity": "sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.12",
@@ -5096,6 +5485,41 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/superagent": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -5130,6 +5554,19 @@
       },
       "engines": {
         "node": ">=14.18.0"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tinybench": {
@@ -5176,6 +5613,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -5183,6 +5640,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/ts-api-utils": {
@@ -5237,6 +5707,22 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
+      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -5304,6 +5790,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
       }
     },
     "node_modules/uri-js": {
@@ -5550,6 +6046,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -5565,6 +6076,45 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -5573,6 +6123,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/supertest": "^7.2.0",
     "eslint": "^10.2.0",
     "eslint-config-prettier": "^10.1.8",
+    "msw": "^2.12.14",
     "prettier": "^3.8.1",
     "prisma": "^7.6.0",
     "supertest": "^7.2.2",

--- a/src/engine/policy.test.ts
+++ b/src/engine/policy.test.ts
@@ -1,0 +1,477 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { validatePolicyConfig, evaluatePolicies } from "./policy.js";
+
+// ---------- validatePolicyConfig ----------
+
+describe("validatePolicyConfig", () => {
+  it("rejects non-object config", () => {
+    expect(validatePolicyConfig("regex", null)).toBe("config must be a JSON object");
+    expect(validatePolicyConfig("regex", "string")).toBe("config must be a JSON object");
+    expect(validatePolicyConfig("regex", [1])).toBe("config must be a JSON object");
+  });
+
+  describe("regex", () => {
+    it("accepts valid regex config", () => {
+      expect(validatePolicyConfig("regex", { pattern: "foo.*bar" })).toBeNull();
+    });
+    it("accepts regex with flags", () => {
+      expect(validatePolicyConfig("regex", { pattern: "test", flags: "gi" })).toBeNull();
+    });
+    it("rejects missing pattern", () => {
+      expect(validatePolicyConfig("regex", {})).toContain("pattern");
+    });
+    it("rejects invalid regex", () => {
+      expect(validatePolicyConfig("regex", { pattern: "[invalid" })).toContain("invalid pattern");
+    });
+  });
+
+  describe("keyword_blocklist", () => {
+    it("accepts valid config", () => {
+      expect(validatePolicyConfig("keyword_blocklist", { keywords: ["spam"] })).toBeNull();
+    });
+    it("rejects empty keywords", () => {
+      expect(validatePolicyConfig("keyword_blocklist", { keywords: [] })).toContain("non-empty");
+    });
+    it("rejects non-string keywords", () => {
+      expect(validatePolicyConfig("keyword_blocklist", { keywords: [123] })).toContain("strings");
+    });
+  });
+
+  describe("content_length", () => {
+    it("accepts min only", () => {
+      expect(validatePolicyConfig("content_length", { min: 10 })).toBeNull();
+    });
+    it("accepts max only", () => {
+      expect(validatePolicyConfig("content_length", { max: 1000 })).toBeNull();
+    });
+    it("accepts min and max", () => {
+      expect(validatePolicyConfig("content_length", { min: 10, max: 1000 })).toBeNull();
+    });
+    it("rejects neither min nor max", () => {
+      expect(validatePolicyConfig("content_length", {})).toContain("at least");
+    });
+    it("rejects min > max", () => {
+      expect(validatePolicyConfig("content_length", { min: 100, max: 10 })).toContain("<=");
+    });
+  });
+
+  describe("required_fields", () => {
+    it("accepts valid config", () => {
+      expect(validatePolicyConfig("required_fields", { fields: ["title"] })).toBeNull();
+    });
+    it("rejects empty fields", () => {
+      expect(validatePolicyConfig("required_fields", { fields: [] })).toContain("non-empty");
+    });
+  });
+
+  describe("webhook", () => {
+    it("accepts valid config", () => {
+      expect(validatePolicyConfig("webhook", { url: "https://example.com/hook" })).toBeNull();
+    });
+    it("rejects missing url", () => {
+      expect(validatePolicyConfig("webhook", {})).toContain("url");
+    });
+  });
+
+  it("rejects unknown type", () => {
+    expect(validatePolicyConfig("unknown_type", {})).toContain("unknown policy type");
+  });
+});
+
+// ---------- evaluatePolicies ----------
+
+function mockPrisma(policies: Record<string, unknown>[]) {
+  return {
+    policy: {
+      findMany: vi.fn().mockResolvedValue(policies),
+    },
+  } as unknown as Parameters<typeof evaluatePolicies>[0];
+}
+
+describe("evaluatePolicies", () => {
+  describe("regex", () => {
+    it("matches content against pattern", async () => {
+      const prisma = mockPrisma([
+        {
+          id: "1",
+          name: "no-urls",
+          type: "regex",
+          config: { pattern: "https?://" },
+          action: "block",
+          priority: 0,
+          active: true,
+          scopeChannel: null,
+          scopeContentType: null,
+        },
+      ]);
+      const results = await evaluatePolicies(prisma, {
+        content: "visit https://evil.com",
+        metadata: {},
+      });
+      expect(results).toHaveLength(1);
+      expect(results[0].result).toBe("match");
+      expect(results[0].action).toBe("block");
+    });
+
+    it("passes when no match", async () => {
+      const prisma = mockPrisma([
+        {
+          id: "1",
+          name: "no-urls",
+          type: "regex",
+          config: { pattern: "https?://" },
+          action: "block",
+          priority: 0,
+          active: true,
+          scopeChannel: null,
+          scopeContentType: null,
+        },
+      ]);
+      const results = await evaluatePolicies(prisma, { content: "clean text", metadata: {} });
+      expect(results[0].result).toBe("pass");
+    });
+  });
+
+  describe("keyword_blocklist", () => {
+    it("flags content with blocked keywords (case-insensitive)", async () => {
+      const prisma = mockPrisma([
+        {
+          id: "1",
+          name: "profanity",
+          type: "keyword_blocklist",
+          config: { keywords: ["spam", "scam"] },
+          action: "flag",
+          priority: 0,
+          active: true,
+          scopeChannel: null,
+          scopeContentType: null,
+        },
+      ]);
+      const results = await evaluatePolicies(prisma, {
+        content: "This is SPAM content",
+        metadata: {},
+      });
+      expect(results[0].result).toBe("match");
+      expect(results[0].action).toBe("flag");
+      expect(results[0].detail).toContain("spam");
+    });
+
+    it("passes clean content", async () => {
+      const prisma = mockPrisma([
+        {
+          id: "1",
+          name: "profanity",
+          type: "keyword_blocklist",
+          config: { keywords: ["spam"] },
+          action: "flag",
+          priority: 0,
+          active: true,
+          scopeChannel: null,
+          scopeContentType: null,
+        },
+      ]);
+      const results = await evaluatePolicies(prisma, { content: "Normal text", metadata: {} });
+      expect(results[0].result).toBe("pass");
+    });
+  });
+
+  describe("content_length", () => {
+    it("flags content below minimum", async () => {
+      const prisma = mockPrisma([
+        {
+          id: "1",
+          name: "min-length",
+          type: "content_length",
+          config: { min: 50 },
+          action: "block",
+          priority: 0,
+          active: true,
+          scopeChannel: null,
+          scopeContentType: null,
+        },
+      ]);
+      const results = await evaluatePolicies(prisma, { content: "short", metadata: {} });
+      expect(results[0].result).toBe("match");
+      expect(results[0].detail).toContain("below minimum");
+    });
+
+    it("flags content above maximum", async () => {
+      const prisma = mockPrisma([
+        {
+          id: "1",
+          name: "max-length",
+          type: "content_length",
+          config: { max: 5 },
+          action: "block",
+          priority: 0,
+          active: true,
+          scopeChannel: null,
+          scopeContentType: null,
+        },
+      ]);
+      const results = await evaluatePolicies(prisma, { content: "too long text", metadata: {} });
+      expect(results[0].result).toBe("match");
+      expect(results[0].detail).toContain("exceeds maximum");
+    });
+
+    it("passes content within bounds", async () => {
+      const prisma = mockPrisma([
+        {
+          id: "1",
+          name: "length",
+          type: "content_length",
+          config: { min: 1, max: 100 },
+          action: "block",
+          priority: 0,
+          active: true,
+          scopeChannel: null,
+          scopeContentType: null,
+        },
+      ]);
+      const results = await evaluatePolicies(prisma, { content: "just right", metadata: {} });
+      expect(results[0].result).toBe("pass");
+    });
+  });
+
+  describe("required_fields", () => {
+    it("flags missing metadata fields", async () => {
+      const prisma = mockPrisma([
+        {
+          id: "1",
+          name: "req-fields",
+          type: "required_fields",
+          config: { fields: ["title", "author"] },
+          action: "flag",
+          priority: 0,
+          active: true,
+          scopeChannel: null,
+          scopeContentType: null,
+        },
+      ]);
+      const results = await evaluatePolicies(prisma, {
+        content: "text",
+        metadata: { title: "hi" },
+      });
+      expect(results[0].result).toBe("match");
+      expect(results[0].detail).toContain("author");
+    });
+
+    it("passes when all fields present", async () => {
+      const prisma = mockPrisma([
+        {
+          id: "1",
+          name: "req-fields",
+          type: "required_fields",
+          config: { fields: ["title"] },
+          action: "flag",
+          priority: 0,
+          active: true,
+          scopeChannel: null,
+          scopeContentType: null,
+        },
+      ]);
+      const results = await evaluatePolicies(prisma, {
+        content: "text",
+        metadata: { title: "hi" },
+      });
+      expect(results[0].result).toBe("pass");
+    });
+  });
+
+  describe("scope filtering", () => {
+    it("skips policies scoped to a different channel", async () => {
+      const prisma = mockPrisma([
+        {
+          id: "1",
+          name: "ch-only",
+          type: "regex",
+          config: { pattern: ".*" },
+          action: "block",
+          priority: 0,
+          active: true,
+          scopeChannel: "blog",
+          scopeContentType: null,
+        },
+      ]);
+      const results = await evaluatePolicies(prisma, {
+        content: "anything",
+        metadata: {},
+        channel: "forum",
+      });
+      expect(results).toHaveLength(0);
+    });
+
+    it("applies policies scoped to matching channel", async () => {
+      const prisma = mockPrisma([
+        {
+          id: "1",
+          name: "ch-only",
+          type: "regex",
+          config: { pattern: ".*" },
+          action: "block",
+          priority: 0,
+          active: true,
+          scopeChannel: "blog",
+          scopeContentType: null,
+        },
+      ]);
+      const results = await evaluatePolicies(prisma, {
+        content: "anything",
+        metadata: {},
+        channel: "blog",
+      });
+      expect(results).toHaveLength(1);
+    });
+
+    it("skips policies scoped to a different content type", async () => {
+      const prisma = mockPrisma([
+        {
+          id: "1",
+          name: "ct-only",
+          type: "regex",
+          config: { pattern: ".*" },
+          action: "block",
+          priority: 0,
+          active: true,
+          scopeChannel: null,
+          scopeContentType: "image",
+        },
+      ]);
+      const results = await evaluatePolicies(prisma, {
+        content: "text",
+        metadata: {},
+        contentType: "text",
+      });
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe("priority ordering", () => {
+    it("evaluates policies in priority order", async () => {
+      const prisma = mockPrisma([
+        {
+          id: "2",
+          name: "second",
+          type: "regex",
+          config: { pattern: "x" },
+          action: "info",
+          priority: 10,
+          active: true,
+          scopeChannel: null,
+          scopeContentType: null,
+        },
+        {
+          id: "1",
+          name: "first",
+          type: "regex",
+          config: { pattern: "x" },
+          action: "block",
+          priority: 1,
+          active: true,
+          scopeChannel: null,
+          scopeContentType: null,
+        },
+      ]);
+      const results = await evaluatePolicies(prisma, { content: "x", metadata: {} });
+      expect(results[0].policyName).toBe("second");
+      expect(results[1].policyName).toBe("first");
+    });
+  });
+
+  describe("webhook", () => {
+    const server = setupServer();
+    beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+    afterAll(() => server.close());
+
+    it("passes when webhook returns pass", async () => {
+      server.use(http.post("https://hook.test/check", () => HttpResponse.json({ result: "pass" })));
+      const prisma = mockPrisma([
+        {
+          id: "1",
+          name: "hook",
+          type: "webhook",
+          config: { url: "https://hook.test/check" },
+          action: "block",
+          priority: 0,
+          active: true,
+          scopeChannel: null,
+          scopeContentType: null,
+        },
+      ]);
+      const results = await evaluatePolicies(prisma, { content: "text", metadata: {} });
+      expect(results[0].result).toBe("pass");
+    });
+
+    it("blocks when webhook returns block", async () => {
+      server.use(
+        http.post("https://hook.test/block", () => HttpResponse.json({ result: "block" })),
+      );
+      const prisma = mockPrisma([
+        {
+          id: "1",
+          name: "hook",
+          type: "webhook",
+          config: { url: "https://hook.test/block" },
+          action: "info",
+          priority: 0,
+          active: true,
+          scopeChannel: null,
+          scopeContentType: null,
+        },
+      ]);
+      const results = await evaluatePolicies(prisma, { content: "text", metadata: {} });
+      expect(results[0].result).toBe("match");
+      expect(results[0].detail).toBe("Webhook blocked");
+    });
+
+    it("flags on webhook timeout", async () => {
+      server.use(
+        http.post("https://hook.test/slow", async () => {
+          await new Promise((r) => setTimeout(r, 10000));
+          return HttpResponse.json({ result: "pass" });
+        }),
+      );
+      const prisma = mockPrisma([
+        {
+          id: "1",
+          name: "hook",
+          type: "webhook",
+          config: { url: "https://hook.test/slow", timeout_ms: 50 },
+          action: "block",
+          priority: 0,
+          active: true,
+          scopeChannel: null,
+          scopeContentType: null,
+        },
+      ]);
+      const results = await evaluatePolicies(prisma, { content: "text", metadata: {} });
+      expect(results[0].result).toBe("match");
+      expect(results[0].action).toBe("flag");
+      expect(results[0].detail).toContain("error");
+    });
+
+    it("flags on non-ok webhook response", async () => {
+      server.use(
+        http.post("https://hook.test/error", () => new HttpResponse(null, { status: 500 })),
+      );
+      const prisma = mockPrisma([
+        {
+          id: "1",
+          name: "hook",
+          type: "webhook",
+          config: { url: "https://hook.test/error" },
+          action: "block",
+          priority: 0,
+          active: true,
+          scopeChannel: null,
+          scopeContentType: null,
+        },
+      ]);
+      const results = await evaluatePolicies(prisma, { content: "text", metadata: {} });
+      expect(results[0].result).toBe("match");
+      expect(results[0].action).toBe("flag");
+    });
+  });
+});

--- a/src/engine/policy.ts
+++ b/src/engine/policy.ts
@@ -1,0 +1,275 @@
+import type { PrismaClient } from "../generated/prisma/client.js";
+
+export const POLICY_TYPES = [
+  "regex",
+  "keyword_blocklist",
+  "content_length",
+  "required_fields",
+  "webhook",
+] as const;
+export type PolicyType = (typeof POLICY_TYPES)[number];
+
+export interface PolicyResult {
+  policyName: string;
+  result: "pass" | "match";
+  action: "block" | "flag" | "info";
+  detail: string;
+}
+
+interface RegexConfig {
+  pattern: string;
+  flags?: string;
+}
+
+interface KeywordBlocklistConfig {
+  keywords: string[];
+}
+
+interface ContentLengthConfig {
+  min?: number;
+  max?: number;
+}
+
+interface RequiredFieldsConfig {
+  fields: string[];
+}
+
+interface WebhookConfig {
+  url: string;
+  timeout_ms?: number;
+}
+
+export function validatePolicyConfig(type: string, config: unknown): string | null {
+  if (!config || typeof config !== "object" || Array.isArray(config)) {
+    return "config must be a JSON object";
+  }
+
+  switch (type) {
+    case "regex": {
+      const c = config as Record<string, unknown>;
+      if (typeof c.pattern !== "string" || c.pattern.length === 0) {
+        return "regex config requires a non-empty 'pattern' string";
+      }
+      try {
+        new RegExp(c.pattern, typeof c.flags === "string" ? c.flags : undefined);
+      } catch {
+        return "regex config has an invalid pattern";
+      }
+      return null;
+    }
+    case "keyword_blocklist": {
+      const c = config as Record<string, unknown>;
+      if (!Array.isArray(c.keywords) || c.keywords.length === 0) {
+        return "keyword_blocklist config requires a non-empty 'keywords' array";
+      }
+      if (!c.keywords.every((k: unknown) => typeof k === "string")) {
+        return "keyword_blocklist keywords must all be strings";
+      }
+      return null;
+    }
+    case "content_length": {
+      const c = config as Record<string, unknown>;
+      if (c.min === undefined && c.max === undefined) {
+        return "content_length config requires at least 'min' or 'max'";
+      }
+      if (c.min !== undefined && (typeof c.min !== "number" || c.min < 0)) {
+        return "content_length 'min' must be a non-negative number";
+      }
+      if (c.max !== undefined && (typeof c.max !== "number" || c.max < 0)) {
+        return "content_length 'max' must be a non-negative number";
+      }
+      if (c.min !== undefined && c.max !== undefined && (c.min as number) > (c.max as number)) {
+        return "content_length 'min' must be <= 'max'";
+      }
+      return null;
+    }
+    case "required_fields": {
+      const c = config as Record<string, unknown>;
+      if (!Array.isArray(c.fields) || c.fields.length === 0) {
+        return "required_fields config requires a non-empty 'fields' array";
+      }
+      if (!c.fields.every((f: unknown) => typeof f === "string")) {
+        return "required_fields fields must all be strings";
+      }
+      return null;
+    }
+    case "webhook": {
+      const c = config as Record<string, unknown>;
+      if (typeof c.url !== "string" || c.url.length === 0) {
+        return "webhook config requires a non-empty 'url' string";
+      }
+      return null;
+    }
+    default:
+      return `unknown policy type: ${type}`;
+  }
+}
+
+function evaluateRegex(content: string, config: RegexConfig): { match: boolean; detail: string } {
+  const re = new RegExp(config.pattern, config.flags);
+  const matched = re.test(content);
+  return {
+    match: matched,
+    detail: matched ? `Content matched pattern /${config.pattern}/` : "No match",
+  };
+}
+
+function evaluateKeywordBlocklist(
+  content: string,
+  config: KeywordBlocklistConfig,
+): { match: boolean; detail: string } {
+  const lower = content.toLowerCase();
+  const found = config.keywords.filter((kw) => lower.includes(kw.toLowerCase()));
+  return {
+    match: found.length > 0,
+    detail:
+      found.length > 0
+        ? `Blocked keywords found: ${found.join(", ")}`
+        : "No blocked keywords found",
+  };
+}
+
+function evaluateContentLength(
+  content: string,
+  config: ContentLengthConfig,
+): { match: boolean; detail: string } {
+  const len = content.length;
+  if (config.min !== undefined && len < config.min) {
+    return { match: true, detail: `Content length ${len} is below minimum ${config.min}` };
+  }
+  if (config.max !== undefined && len > config.max) {
+    return { match: true, detail: `Content length ${len} exceeds maximum ${config.max}` };
+  }
+  return { match: false, detail: `Content length ${len} is within bounds` };
+}
+
+function evaluateRequiredFields(
+  metadata: Record<string, unknown>,
+  config: RequiredFieldsConfig,
+): { match: boolean; detail: string } {
+  const missing = config.fields.filter((f) => !(f in metadata));
+  return {
+    match: missing.length > 0,
+    detail:
+      missing.length > 0
+        ? `Missing required fields: ${missing.join(", ")}`
+        : "All required fields present",
+  };
+}
+
+async function evaluateWebhook(
+  content: string,
+  metadata: Record<string, unknown>,
+  config: WebhookConfig,
+): Promise<{ match: boolean; action_override?: "flag"; detail: string }> {
+  const timeoutMs = config.timeout_ms ?? 5000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const resp = await fetch(config.url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content, metadata }),
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+
+    if (!resp.ok) {
+      return {
+        match: true,
+        action_override: "flag",
+        detail: `Webhook returned status ${resp.status}`,
+      };
+    }
+
+    const body = (await resp.json()) as { result?: string };
+    if (body.result === "pass") {
+      return { match: false, detail: "Webhook passed" };
+    }
+    if (body.result === "block") {
+      return { match: true, detail: "Webhook blocked" };
+    }
+    // "flag" or any other value
+    return {
+      match: true,
+      action_override: "flag",
+      detail: `Webhook flagged: ${body.result ?? "unknown"}`,
+    };
+  } catch (err) {
+    clearTimeout(timer);
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return { match: true, action_override: "flag", detail: `Webhook error (flagging): ${message}` };
+  }
+}
+
+export interface EvaluateInput {
+  content: string;
+  metadata: Record<string, unknown>;
+  channel?: string | null;
+  contentType?: string | null;
+}
+
+export async function evaluatePolicies(
+  prisma: PrismaClient,
+  input: EvaluateInput,
+): Promise<PolicyResult[]> {
+  const policies = await prisma.policy.findMany({
+    where: { active: true },
+    orderBy: { priority: "asc" },
+  });
+
+  const applicable = policies.filter((p) => {
+    if (p.scopeChannel && p.scopeChannel !== input.channel) return false;
+    if (p.scopeContentType && p.scopeContentType !== input.contentType) return false;
+    return true;
+  });
+
+  const results: PolicyResult[] = [];
+
+  for (const policy of applicable) {
+    const config = policy.config as Record<string, unknown>;
+    let evalResult: { match: boolean; action_override?: string; detail: string };
+
+    switch (policy.type) {
+      case "regex":
+        evalResult = evaluateRegex(input.content, config as unknown as RegexConfig);
+        break;
+      case "keyword_blocklist":
+        evalResult = evaluateKeywordBlocklist(
+          input.content,
+          config as unknown as KeywordBlocklistConfig,
+        );
+        break;
+      case "content_length":
+        evalResult = evaluateContentLength(input.content, config as unknown as ContentLengthConfig);
+        break;
+      case "required_fields":
+        evalResult = evaluateRequiredFields(
+          input.metadata,
+          config as unknown as RequiredFieldsConfig,
+        );
+        break;
+      case "webhook":
+        evalResult = await evaluateWebhook(
+          input.content,
+          input.metadata,
+          config as unknown as WebhookConfig,
+        );
+        break;
+      default:
+        evalResult = { match: false, detail: `Unknown policy type: ${policy.type}` };
+    }
+
+    const action = evalResult.action_override ?? policy.action;
+
+    results.push({
+      policyName: policy.name,
+      result: evalResult.match ? "match" : "pass",
+      action: action as PolicyResult["action"],
+      detail: evalResult.detail,
+    });
+  }
+
+  return results;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { config } from "./config.js";
 import { createHealthRouter } from "./health.js";
 import { createAuthMiddleware } from "./middleware/auth.js";
 import { createApiKeyRouter } from "./routes/api-keys.js";
+import { createPolicyRouter } from "./routes/policies.js";
 
 const pool = new pg.Pool({ connectionString: config.databaseUrl });
 const adapter = new PrismaPg(pool);
@@ -25,6 +26,7 @@ app.use("/api/v1", auth);
 
 // Authenticated routes
 app.use("/api/v1/api-keys", createApiKeyRouter(prisma));
+app.use("/api/v1/policies", createPolicyRouter(prisma));
 
 async function start(): Promise<void> {
   app.listen(config.port, () => {

--- a/src/routes/policies.test.ts
+++ b/src/routes/policies.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+import { createPolicyRouter } from "./policies.js";
+
+const UUID = "00000000-0000-0000-0000-000000000001";
+
+function buildApp(mockPrisma: Record<string, unknown>) {
+  const prisma = { policy: mockPrisma } as unknown as Parameters<typeof createPolicyRouter>[0];
+  const app = express();
+  app.use(express.json());
+  app.use("/api/v1/policies", createPolicyRouter(prisma));
+  return app;
+}
+
+describe("POST /api/v1/policies", () => {
+  it("creates a regex policy", async () => {
+    const createFn = vi
+      .fn()
+      .mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+        id: UUID,
+        ...data,
+        active: true,
+        createdAt: new Date("2026-01-01"),
+      }));
+    const app = buildApp({ create: createFn });
+    const res = await request(app)
+      .post("/api/v1/policies")
+      .send({
+        name: "no-urls",
+        type: "regex",
+        config: { pattern: "https?://" },
+        action: "block",
+        priority: 1,
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBe(UUID);
+    expect(res.body.name).toBe("no-urls");
+    expect(res.body.type).toBe("regex");
+    expect(res.body.action).toBe("block");
+    expect(res.body.priority).toBe(1);
+    expect(createFn).toHaveBeenCalledOnce();
+  });
+
+  it("creates a keyword_blocklist policy", async () => {
+    const createFn = vi
+      .fn()
+      .mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+        id: UUID,
+        ...data,
+        active: true,
+        createdAt: new Date("2026-01-01"),
+      }));
+    const app = buildApp({ create: createFn });
+    const res = await request(app)
+      .post("/api/v1/policies")
+      .send({
+        name: "profanity",
+        type: "keyword_blocklist",
+        config: { keywords: ["spam", "scam"] },
+        action: "flag",
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.type).toBe("keyword_blocklist");
+  });
+
+  it("returns 400 when name is missing", async () => {
+    const app = buildApp({});
+    const res = await request(app)
+      .post("/api/v1/policies")
+      .send({ type: "regex", config: { pattern: "x" }, action: "block" });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain("name");
+  });
+
+  it("returns 400 for invalid type", async () => {
+    const app = buildApp({});
+    const res = await request(app)
+      .post("/api/v1/policies")
+      .send({ name: "test", type: "invalid", config: {}, action: "block" });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain("type");
+  });
+
+  it("returns 400 for invalid action", async () => {
+    const app = buildApp({});
+    const res = await request(app)
+      .post("/api/v1/policies")
+      .send({ name: "test", type: "regex", config: { pattern: "x" }, action: "destroy" });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain("action");
+  });
+
+  it("returns 400 when config doesn't match type", async () => {
+    const app = buildApp({});
+    const res = await request(app)
+      .post("/api/v1/policies")
+      .send({ name: "test", type: "regex", config: {}, action: "block" });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain("pattern");
+  });
+
+  it("accepts scope_channel and scope_content_type", async () => {
+    const createFn = vi
+      .fn()
+      .mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+        id: UUID,
+        ...data,
+        active: true,
+        createdAt: new Date("2026-01-01"),
+      }));
+    const app = buildApp({ create: createFn });
+    const res = await request(app)
+      .post("/api/v1/policies")
+      .send({
+        name: "blog-regex",
+        type: "regex",
+        config: { pattern: "test" },
+        action: "info",
+        scope_channel: "blog",
+        scope_content_type: "article",
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.scope_channel).toBe("blog");
+    expect(res.body.scope_content_type).toBe("article");
+  });
+});
+
+describe("GET /api/v1/policies", () => {
+  it("lists active policies", async () => {
+    const findManyFn = vi.fn().mockResolvedValue([
+      {
+        id: UUID,
+        name: "p1",
+        type: "regex",
+        config: { pattern: "x" },
+        action: "block",
+        scopeChannel: null,
+        scopeContentType: null,
+        priority: 0,
+        active: true,
+        createdAt: new Date("2026-01-01"),
+      },
+    ]);
+    const app = buildApp({ findMany: findManyFn });
+    const res = await request(app).get("/api/v1/policies");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].name).toBe("p1");
+    expect(findManyFn).toHaveBeenCalledWith(expect.objectContaining({ where: { active: true } }));
+  });
+});
+
+describe("GET /api/v1/policies/:id", () => {
+  it("returns a single policy", async () => {
+    const findUniqueFn = vi.fn().mockResolvedValue({
+      id: UUID,
+      name: "p1",
+      type: "regex",
+      config: { pattern: "x" },
+      action: "block",
+      scopeChannel: null,
+      scopeContentType: null,
+      priority: 0,
+      active: true,
+      createdAt: new Date("2026-01-01"),
+    });
+    const app = buildApp({ findUnique: findUniqueFn });
+    const res = await request(app).get(`/api/v1/policies/${UUID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe("p1");
+  });
+
+  it("returns 404 for non-existent policy", async () => {
+    const app = buildApp({ findUnique: vi.fn().mockResolvedValue(null) });
+    const res = await request(app).get(`/api/v1/policies/${UUID}`);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 for invalid UUID", async () => {
+    const app = buildApp({});
+    const res = await request(app).get("/api/v1/policies/not-a-uuid");
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("PUT /api/v1/policies/:id", () => {
+  it("updates a policy", async () => {
+    const existing = {
+      id: UUID,
+      name: "old-name",
+      type: "regex",
+      config: { pattern: "old" },
+      action: "block",
+      scopeChannel: null,
+      scopeContentType: null,
+      priority: 0,
+      active: true,
+      createdAt: new Date("2026-01-01"),
+    };
+    const updateFn = vi
+      .fn()
+      .mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+        ...existing,
+        ...data,
+      }));
+    const app = buildApp({ findUnique: vi.fn().mockResolvedValue(existing), update: updateFn });
+    const res = await request(app)
+      .put(`/api/v1/policies/${UUID}`)
+      .send({ name: "new-name", priority: 5 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe("new-name");
+    expect(res.body.priority).toBe(5);
+    expect(updateFn).toHaveBeenCalledOnce();
+  });
+
+  it("returns 404 for non-existent policy", async () => {
+    const app = buildApp({ findUnique: vi.fn().mockResolvedValue(null) });
+    const res = await request(app).put(`/api/v1/policies/${UUID}`).send({ name: "x" });
+    expect(res.status).toBe(404);
+  });
+
+  it("validates config when type changes", async () => {
+    const existing = {
+      id: UUID,
+      name: "p",
+      type: "regex",
+      config: { pattern: "x" },
+      action: "block",
+      scopeChannel: null,
+      scopeContentType: null,
+      priority: 0,
+      active: true,
+      createdAt: new Date(),
+    };
+    const app = buildApp({ findUnique: vi.fn().mockResolvedValue(existing) });
+    const res = await request(app)
+      .put(`/api/v1/policies/${UUID}`)
+      .send({ type: "keyword_blocklist" });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain("keywords");
+  });
+});
+
+describe("DELETE /api/v1/policies/:id", () => {
+  it("soft-deletes a policy", async () => {
+    const updateFn = vi.fn().mockResolvedValue({});
+    const app = buildApp({
+      findUnique: vi.fn().mockResolvedValue({ id: UUID, active: true }),
+      update: updateFn,
+    });
+    const res = await request(app).delete(`/api/v1/policies/${UUID}`);
+
+    expect(res.status).toBe(204);
+    expect(updateFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: UUID },
+        data: { active: false },
+      }),
+    );
+  });
+
+  it("returns 404 for non-existent policy", async () => {
+    const app = buildApp({ findUnique: vi.fn().mockResolvedValue(null) });
+    const res = await request(app).delete(`/api/v1/policies/${UUID}`);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for already-deleted policy", async () => {
+    const app = buildApp({ findUnique: vi.fn().mockResolvedValue({ id: UUID, active: false }) });
+    const res = await request(app).delete(`/api/v1/policies/${UUID}`);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 for invalid UUID", async () => {
+    const app = buildApp({});
+    const res = await request(app).delete("/api/v1/policies/bad-id");
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/routes/policies.ts
+++ b/src/routes/policies.ts
@@ -1,0 +1,220 @@
+import { Router } from "express";
+import type { PrismaClient } from "../generated/prisma/client.js";
+import { POLICY_TYPES, validatePolicyConfig } from "../engine/policy.js";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const VALID_ACTIONS = ["block", "flag", "info"] as const;
+
+export function createPolicyRouter(prisma: PrismaClient): Router {
+  const router = Router();
+
+  router.post("/", async (req, res) => {
+    const { name, type, config, action, scope_channel, scope_content_type, priority } =
+      req.body as {
+        name?: string;
+        type?: string;
+        config?: unknown;
+        action?: string;
+        scope_channel?: string;
+        scope_content_type?: string;
+        priority?: number;
+      };
+
+    if (!name || typeof name !== "string" || name.trim().length === 0) {
+      res.status(400).json({ error: "bad_request", message: "name is required" });
+      return;
+    }
+    if (!type || !POLICY_TYPES.includes(type as (typeof POLICY_TYPES)[number])) {
+      res
+        .status(400)
+        .json({ error: "bad_request", message: `type must be one of: ${POLICY_TYPES.join(", ")}` });
+      return;
+    }
+    if (!action || !VALID_ACTIONS.includes(action as (typeof VALID_ACTIONS)[number])) {
+      res.status(400).json({
+        error: "bad_request",
+        message: `action must be one of: ${VALID_ACTIONS.join(", ")}`,
+      });
+      return;
+    }
+
+    const configError = validatePolicyConfig(type, config);
+    if (configError) {
+      res.status(400).json({ error: "bad_request", message: configError });
+      return;
+    }
+
+    const policy = await prisma.policy.create({
+      data: {
+        name: name.trim(),
+        type,
+        config: config as object,
+        action: action as "block" | "flag" | "info",
+        scopeChannel: scope_channel ?? null,
+        scopeContentType: scope_content_type ?? null,
+        priority: typeof priority === "number" ? priority : 0,
+      },
+    });
+
+    res.status(201).json({
+      id: policy.id,
+      name: policy.name,
+      type: policy.type,
+      config: policy.config,
+      action: policy.action,
+      scope_channel: policy.scopeChannel,
+      scope_content_type: policy.scopeContentType,
+      priority: policy.priority,
+      active: policy.active,
+      created_at: policy.createdAt,
+    });
+  });
+
+  router.get("/", async (_req, res) => {
+    const policies = await prisma.policy.findMany({
+      where: { active: true },
+      orderBy: { priority: "asc" },
+    });
+
+    res.json(
+      policies.map((p) => ({
+        id: p.id,
+        name: p.name,
+        type: p.type,
+        config: p.config,
+        action: p.action,
+        scope_channel: p.scopeChannel,
+        scope_content_type: p.scopeContentType,
+        priority: p.priority,
+        active: p.active,
+        created_at: p.createdAt,
+      })),
+    );
+  });
+
+  router.get("/:id", async (req, res) => {
+    const { id } = req.params;
+    if (!UUID_RE.test(id)) {
+      res.status(400).json({ error: "bad_request", message: "Invalid policy ID" });
+      return;
+    }
+
+    const policy = await prisma.policy.findUnique({ where: { id } });
+    if (!policy || !policy.active) {
+      res.status(404).json({ error: "not_found", message: "Policy not found" });
+      return;
+    }
+
+    res.json({
+      id: policy.id,
+      name: policy.name,
+      type: policy.type,
+      config: policy.config,
+      action: policy.action,
+      scope_channel: policy.scopeChannel,
+      scope_content_type: policy.scopeContentType,
+      priority: policy.priority,
+      active: policy.active,
+      created_at: policy.createdAt,
+    });
+  });
+
+  router.put("/:id", async (req, res) => {
+    const { id } = req.params;
+    if (!UUID_RE.test(id)) {
+      res.status(400).json({ error: "bad_request", message: "Invalid policy ID" });
+      return;
+    }
+
+    const existing = await prisma.policy.findUnique({ where: { id } });
+    if (!existing || !existing.active) {
+      res.status(404).json({ error: "not_found", message: "Policy not found" });
+      return;
+    }
+
+    const { name, type, config, action, scope_channel, scope_content_type, priority } =
+      req.body as {
+        name?: string;
+        type?: string;
+        config?: unknown;
+        action?: string;
+        scope_channel?: string | null;
+        scope_content_type?: string | null;
+        priority?: number;
+      };
+
+    const updatedType = type ?? existing.type;
+    const updatedConfig = config ?? existing.config;
+
+    if (type && !POLICY_TYPES.includes(type as (typeof POLICY_TYPES)[number])) {
+      res
+        .status(400)
+        .json({ error: "bad_request", message: `type must be one of: ${POLICY_TYPES.join(", ")}` });
+      return;
+    }
+    if (action && !VALID_ACTIONS.includes(action as (typeof VALID_ACTIONS)[number])) {
+      res.status(400).json({
+        error: "bad_request",
+        message: `action must be one of: ${VALID_ACTIONS.join(", ")}`,
+      });
+      return;
+    }
+
+    if (config !== undefined || type !== undefined) {
+      const configError = validatePolicyConfig(updatedType, updatedConfig);
+      if (configError) {
+        res.status(400).json({ error: "bad_request", message: configError });
+        return;
+      }
+    }
+
+    const policy = await prisma.policy.update({
+      where: { id },
+      data: {
+        ...(name !== undefined && { name: name.trim() }),
+        ...(type !== undefined && { type }),
+        ...(config !== undefined && { config: config as object }),
+        ...(action !== undefined && { action: action as "block" | "flag" | "info" }),
+        ...(scope_channel !== undefined && { scopeChannel: scope_channel }),
+        ...(scope_content_type !== undefined && { scopeContentType: scope_content_type }),
+        ...(priority !== undefined && { priority }),
+      },
+    });
+
+    res.json({
+      id: policy.id,
+      name: policy.name,
+      type: policy.type,
+      config: policy.config,
+      action: policy.action,
+      scope_channel: policy.scopeChannel,
+      scope_content_type: policy.scopeContentType,
+      priority: policy.priority,
+      active: policy.active,
+      created_at: policy.createdAt,
+    });
+  });
+
+  router.delete("/:id", async (req, res) => {
+    const { id } = req.params;
+    if (!UUID_RE.test(id)) {
+      res.status(400).json({ error: "bad_request", message: "Invalid policy ID" });
+      return;
+    }
+
+    const existing = await prisma.policy.findUnique({ where: { id } });
+    if (!existing || !existing.active) {
+      res.status(404).json({ error: "not_found", message: "Policy not found" });
+      return;
+    }
+
+    await prisma.policy.update({
+      where: { id },
+      data: { active: false },
+    });
+
+    res.status(204).end();
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary

Implements issue #4 — configurable policy engine with 5 built-in rule types and full CRUD API for managing policies.

- **Policy engine** (`src/engine/policy.ts`): Evaluates content against configured rules in priority order with channel/content-type scoping
  - `regex`: matches content against configurable patterns
  - `keyword_blocklist`: case-insensitive keyword detection
  - `content_length`: min/max length enforcement
  - `required_fields`: metadata field presence checking
  - `webhook`: external URL evaluation with 5s timeout, flags on timeout/error
- **Policy CRUD routes** (`src/routes/policies.ts`): POST, GET (list), GET/:id, PUT/:id, DELETE/:id (soft-delete)
- **Request validation**: name required, type must be valid enum, config validated per type, action must be block/flag/info
- **53 new tests** covering engine evaluation, config validation, CRUD operations, scope filtering, and webhook edge cases

### Test Evidence
```
Test Files  6 passed (6)
     Tests  78 passed (78)
```

## Test Plan

- [x] `npm run test` — 78 tests pass (6 files)
- [x] `npm run lint` — ESLint + Prettier clean
- [x] `npx tsc --noEmit` — no type errors
- [x] Codex cross-model review in progress

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)