### PR TITLE
feat: Submission API with policy evaluation

### DIFF
--- a/src/engine/policy.ts
+++ b/src/engine/policy.ts
@@ -10,6 +10,7 @@ export const POLICY_TYPES = [
 export type PolicyType = (typeof POLICY_TYPES)[number];
 
 export interface PolicyResult {
+  policyId: string;
   policyName: string;
   result: "pass" | "match";
   action: "block" | "flag" | "info";
@@ -264,6 +265,7 @@ export async function evaluatePolicies(
     const action = evalResult.action_override ?? policy.action;
 
     results.push({
+      policyId: policy.id,
       policyName: policy.name,
       result: evalResult.match ? "match" : "pass",
       action: action as PolicyResult["action"],

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { createHealthRouter } from "./health.js";
 import { createAuthMiddleware } from "./middleware/auth.js";
 import { createApiKeyRouter } from "./routes/api-keys.js";
 import { createPolicyRouter } from "./routes/policies.js";
+import { createSubmissionRouter } from "./routes/submissions.js";
 
 const pool = new pg.Pool({ connectionString: config.databaseUrl });
 const adapter = new PrismaPg(pool);
@@ -27,6 +28,7 @@ app.use("/api/v1", auth);
 // Authenticated routes
 app.use("/api/v1/api-keys", createApiKeyRouter(prisma));
 app.use("/api/v1/policies", createPolicyRouter(prisma));
+app.use("/api/v1/submissions", createSubmissionRouter(prisma));
 
 async function start(): Promise<void> {
   app.listen(config.port, () => {

--- a/src/routes/submissions.test.ts
+++ b/src/routes/submissions.test.ts
@@ -1,0 +1,394 @@
+import { describe, it, expect, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+import { createSubmissionRouter } from "./submissions.js";
+
+const UUID = "00000000-0000-0000-0000-000000000001";
+
+function buildApp(mockPrisma: Record<string, Record<string, unknown>>) {
+  const prisma = mockPrisma as unknown as Parameters<typeof createSubmissionRouter>[0];
+  const app = express();
+  app.use(express.json());
+  // Simulate auth middleware populating req.apiKey
+  app.use((_req, _res, next) => {
+    _req.apiKey = { id: "api-key-1", name: "test-key" };
+    next();
+  });
+  app.use("/api/v1/submissions", createSubmissionRouter(prisma));
+  return app;
+}
+
+const baseMocks = () => ({
+  policy: {
+    findMany: vi.fn().mockResolvedValue([]),
+  },
+  policyEvaluation: {
+    createMany: vi.fn().mockResolvedValue({ count: 0 }),
+  },
+  submission: {
+    create: vi.fn().mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+      id: UUID,
+      ...data,
+      createdAt: new Date("2026-01-01"),
+    })),
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockResolvedValue(null),
+    count: vi.fn().mockResolvedValue(0),
+  },
+});
+
+describe("POST /api/v1/submissions", () => {
+  it("auto-approves when no policies match", async () => {
+    const mocks = baseMocks();
+    const app = buildApp(mocks);
+    const res = await request(app)
+      .post("/api/v1/submissions")
+      .send({
+        channel: "email",
+        content_type: "text/plain",
+        content: { body: "Hello world" },
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBe(UUID);
+    expect(res.body.status).toBe("approved");
+    expect(res.body.decided_by).toBe("policy");
+    expect(res.body.decided_at).toBeDefined();
+    expect(res.body.policy_results).toEqual([]);
+  });
+
+  it("rejects when a block policy matches", async () => {
+    const mocks = baseMocks();
+    mocks.policy.findMany = vi.fn().mockResolvedValue([
+      {
+        id: "pol-1",
+        name: "no-spam",
+        type: "keyword_blocklist",
+        config: { keywords: ["spam"] },
+        action: "block",
+        priority: 0,
+        active: true,
+        scopeChannel: null,
+        scopeContentType: null,
+      },
+    ]);
+    const app = buildApp(mocks);
+    const res = await request(app)
+      .post("/api/v1/submissions")
+      .send({
+        channel: "email",
+        content_type: "text/plain",
+        content: { body: "This is spam content" },
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.status).toBe("rejected");
+    expect(res.body.decided_by).toBe("policy");
+    expect(res.body.policy_results).toHaveLength(1);
+    expect(res.body.policy_results[0].result).toBe("match");
+    expect(res.body.policy_results[0].action).toBe("block");
+  });
+
+  it("returns pending when a flag policy matches", async () => {
+    const mocks = baseMocks();
+    mocks.policy.findMany = vi.fn().mockResolvedValue([
+      {
+        id: "pol-2",
+        name: "review-urls",
+        type: "regex",
+        config: { pattern: "https?://" },
+        action: "flag",
+        priority: 0,
+        active: true,
+        scopeChannel: null,
+        scopeContentType: null,
+      },
+    ]);
+    const app = buildApp(mocks);
+    const res = await request(app).post("/api/v1/submissions").send({
+      channel: "blog",
+      content_type: "text/html",
+      content: "Visit https://example.com",
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.status).toBe("pending");
+    expect(res.body.decided_by).toBeNull();
+    expect(res.body.review_url).toBeDefined();
+    expect(res.body.estimated_review_time).toBeDefined();
+  });
+
+  it("block takes precedence over flag", async () => {
+    const mocks = baseMocks();
+    mocks.policy.findMany = vi.fn().mockResolvedValue([
+      {
+        id: "pol-1",
+        name: "flag-it",
+        type: "regex",
+        config: { pattern: "test" },
+        action: "flag",
+        priority: 0,
+        active: true,
+        scopeChannel: null,
+        scopeContentType: null,
+      },
+      {
+        id: "pol-2",
+        name: "block-it",
+        type: "regex",
+        config: { pattern: "test" },
+        action: "block",
+        priority: 1,
+        active: true,
+        scopeChannel: null,
+        scopeContentType: null,
+      },
+    ]);
+    const app = buildApp(mocks);
+    const res = await request(app).post("/api/v1/submissions").send({
+      channel: "email",
+      content_type: "text/plain",
+      content: "test content",
+    });
+
+    expect(res.body.status).toBe("rejected");
+  });
+
+  it("stores policy evaluations", async () => {
+    const mocks = baseMocks();
+    mocks.policy.findMany = vi.fn().mockResolvedValue([
+      {
+        id: "pol-1",
+        name: "length-check",
+        type: "content_length",
+        config: { min: 100 },
+        action: "flag",
+        priority: 0,
+        active: true,
+        scopeChannel: null,
+        scopeContentType: null,
+      },
+    ]);
+    const app = buildApp(mocks);
+    await request(app).post("/api/v1/submissions").send({
+      channel: "email",
+      content_type: "text/plain",
+      content: "short",
+    });
+
+    expect(mocks.policyEvaluation.createMany).toHaveBeenCalledOnce();
+    const callData = mocks.policyEvaluation.createMany.mock.calls[0][0].data;
+    expect(callData).toHaveLength(1);
+    expect(callData[0].policyId).toBe("pol-1");
+    expect(callData[0].submissionId).toBe(UUID);
+  });
+
+  it("returns 400 when channel is missing", async () => {
+    const mocks = baseMocks();
+    const app = buildApp(mocks);
+    const res = await request(app).post("/api/v1/submissions").send({
+      content_type: "text/plain",
+      content: "hello",
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain("channel");
+  });
+
+  it("returns 400 when content_type is missing", async () => {
+    const mocks = baseMocks();
+    const app = buildApp(mocks);
+    const res = await request(app).post("/api/v1/submissions").send({
+      channel: "email",
+      content: "hello",
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain("content_type");
+  });
+
+  it("returns 400 when content is missing", async () => {
+    const mocks = baseMocks();
+    const app = buildApp(mocks);
+    const res = await request(app).post("/api/v1/submissions").send({
+      channel: "email",
+      content_type: "text/plain",
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain("content");
+  });
+
+  it("returns 422 for empty content", async () => {
+    const mocks = baseMocks();
+    const app = buildApp(mocks);
+    const res = await request(app).post("/api/v1/submissions").send({
+      channel: "email",
+      content_type: "text/plain",
+      content: {},
+    });
+    expect(res.status).toBe(422);
+    expect(res.body.message).toContain("empty");
+  });
+
+  it("returns 422 for empty string content", async () => {
+    const mocks = baseMocks();
+    const app = buildApp(mocks);
+    const res = await request(app).post("/api/v1/submissions").send({
+      channel: "email",
+      content_type: "text/plain",
+      content: "",
+    });
+    expect(res.status).toBe(422);
+  });
+
+  it("passes metadata to policy engine", async () => {
+    const mocks = baseMocks();
+    mocks.policy.findMany = vi.fn().mockResolvedValue([
+      {
+        id: "pol-1",
+        name: "req-fields",
+        type: "required_fields",
+        config: { fields: ["author"] },
+        action: "flag",
+        priority: 0,
+        active: true,
+        scopeChannel: null,
+        scopeContentType: null,
+      },
+    ]);
+    const app = buildApp(mocks);
+    const res = await request(app)
+      .post("/api/v1/submissions")
+      .send({
+        channel: "blog",
+        content_type: "text/plain",
+        content: "My post",
+        metadata: { author: "Jane" },
+      });
+
+    expect(res.body.status).toBe("approved");
+  });
+
+  it("accepts optional callback_url", async () => {
+    const mocks = baseMocks();
+    const app = buildApp(mocks);
+    const res = await request(app).post("/api/v1/submissions").send({
+      channel: "email",
+      content_type: "text/plain",
+      content: "Hello",
+      callback_url: "https://example.com/webhook",
+    });
+
+    expect(res.status).toBe(201);
+    const createCall = mocks.submission.create.mock.calls[0][0].data;
+    expect(createCall.callbackUrl).toBe("https://example.com/webhook");
+  });
+});
+
+describe("GET /api/v1/submissions/:id", () => {
+  it("returns full submission details", async () => {
+    const mocks = baseMocks();
+    mocks.submission.findUnique = vi.fn().mockResolvedValue({
+      id: UUID,
+      channel: "email",
+      contentType: "text/plain",
+      content: { body: "hello" },
+      metadata: null,
+      status: "approved",
+      reviewMode: null,
+      callbackUrl: null,
+      createdAt: new Date("2026-01-01"),
+      decidedAt: new Date("2026-01-01"),
+      policyEvaluations: [
+        {
+          id: "eval-1",
+          result: "pass",
+          actionTaken: "info",
+          details: null,
+          evaluatedAt: new Date("2026-01-01"),
+          policy: { name: "test-policy" },
+        },
+      ],
+      reviews: [],
+      feedbacks: [],
+    });
+    const app = buildApp(mocks);
+    const res = await request(app).get(`/api/v1/submissions/${UUID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(UUID);
+    expect(res.body.status).toBe("approved");
+    expect(res.body.policy_results).toHaveLength(1);
+    expect(res.body.policy_results[0].policy_name).toBe("test-policy");
+  });
+
+  it("returns 404 for non-existent submission", async () => {
+    const mocks = baseMocks();
+    const app = buildApp(mocks);
+    const res = await request(app).get(`/api/v1/submissions/${UUID}`);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 for invalid UUID", async () => {
+    const mocks = baseMocks();
+    const app = buildApp(mocks);
+    const res = await request(app).get("/api/v1/submissions/bad-id");
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/v1/submissions", () => {
+  it("returns paginated results", async () => {
+    const mocks = baseMocks();
+    mocks.submission.findMany = vi.fn().mockResolvedValue([
+      {
+        id: UUID,
+        channel: "email",
+        contentType: "text/plain",
+        status: "approved",
+        createdAt: new Date("2026-01-01"),
+        decidedAt: new Date("2026-01-01"),
+        policyEvaluations: [],
+      },
+    ]);
+    mocks.submission.count = vi.fn().mockResolvedValue(1);
+    const app = buildApp(mocks);
+    const res = await request(app).get("/api/v1/submissions?limit=10&offset=0");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.total).toBe(1);
+    expect(res.body.limit).toBe(10);
+    expect(res.body.offset).toBe(0);
+  });
+
+  it("filters by status", async () => {
+    const mocks = baseMocks();
+    mocks.submission.findMany = vi.fn().mockResolvedValue([]);
+    mocks.submission.count = vi.fn().mockResolvedValue(0);
+    const app = buildApp(mocks);
+    await request(app).get("/api/v1/submissions?status=pending");
+
+    const findManyCall = mocks.submission.findMany.mock.calls[0][0];
+    expect(findManyCall.where.status).toBe("pending");
+  });
+
+  it("filters by channel", async () => {
+    const mocks = baseMocks();
+    mocks.submission.findMany = vi.fn().mockResolvedValue([]);
+    mocks.submission.count = vi.fn().mockResolvedValue(0);
+    const app = buildApp(mocks);
+    await request(app).get("/api/v1/submissions?channel=email");
+
+    const findManyCall = mocks.submission.findMany.mock.calls[0][0];
+    expect(findManyCall.where.channel).toBe("email");
+  });
+
+  it("caps limit at 100", async () => {
+    const mocks = baseMocks();
+    mocks.submission.findMany = vi.fn().mockResolvedValue([]);
+    mocks.submission.count = vi.fn().mockResolvedValue(0);
+    const app = buildApp(mocks);
+    const res = await request(app).get("/api/v1/submissions?limit=500");
+
+    expect(res.body.limit).toBe(100);
+  });
+});

--- a/src/routes/submissions.ts
+++ b/src/routes/submissions.ts
@@ -1,0 +1,231 @@
+import { Router } from "express";
+import type { PrismaClient } from "../generated/prisma/client.js";
+import { evaluatePolicies } from "../engine/policy.js";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function createSubmissionRouter(prisma: PrismaClient): Router {
+  const router = Router();
+
+  router.post("/", async (req, res) => {
+    const { channel, content_type, content, metadata, callback_url } = req.body as {
+      channel?: string;
+      content_type?: string;
+      content?: unknown;
+      metadata?: Record<string, unknown>;
+      callback_url?: string;
+    };
+
+    if (!channel || typeof channel !== "string" || channel.trim().length === 0) {
+      res.status(400).json({ error: "bad_request", message: "channel is required" });
+      return;
+    }
+    if (!content_type || typeof content_type !== "string" || content_type.trim().length === 0) {
+      res.status(400).json({ error: "bad_request", message: "content_type is required" });
+      return;
+    }
+    if (content === undefined || content === null) {
+      res.status(400).json({ error: "bad_request", message: "content is required" });
+      return;
+    }
+
+    // Check for empty content (empty string or empty object)
+    const contentStr =
+      typeof content === "string"
+        ? content
+        : typeof content === "object"
+          ? JSON.stringify(content)
+          : String(content);
+    if (contentStr.length === 0 || contentStr === "{}") {
+      res.status(422).json({ error: "unprocessable_entity", message: "content must not be empty" });
+      return;
+    }
+
+    const apiKeyId = req.apiKey?.id;
+    if (!apiKeyId) {
+      res.status(401).json({ error: "unauthorized", message: "API key required" });
+      return;
+    }
+
+    // Run policy evaluation
+    const policyResults = await evaluatePolicies(prisma, {
+      content: contentStr,
+      metadata: metadata ?? {},
+      channel: channel.trim(),
+      contentType: content_type.trim(),
+    });
+
+    // Determine status based on policy results
+    const hasBlock = policyResults.some((r) => r.result === "match" && r.action === "block");
+    const hasFlag = policyResults.some((r) => r.result === "match" && r.action === "flag");
+
+    let status: "approved" | "rejected" | "pending";
+    let decidedBy: string | null = null;
+    let decidedAt: Date | null = null;
+
+    if (hasBlock) {
+      status = "rejected";
+      decidedBy = "policy";
+      decidedAt = new Date();
+    } else if (hasFlag) {
+      status = "pending";
+    } else {
+      status = "approved";
+      decidedBy = "policy";
+      decidedAt = new Date();
+    }
+
+    const submission = await prisma.submission.create({
+      data: {
+        apiKeyId,
+        channel: channel.trim(),
+        contentType: content_type.trim(),
+        content: content as object,
+        metadata: (metadata as object) ?? undefined,
+        status,
+        callbackUrl: callback_url ?? null,
+        decidedAt,
+      },
+    });
+
+    // Store policy evaluation results
+    if (policyResults.length > 0) {
+      await prisma.policyEvaluation.createMany({
+        data: policyResults.map((r) => ({
+          submissionId: submission.id,
+          policyId: r.policyId,
+          result: r.result === "match" ? mapAction(r.action) : ("pass" as const),
+          actionTaken: r.action,
+          details: { detail: r.detail },
+        })),
+      });
+    }
+
+    const response: Record<string, unknown> = {
+      id: submission.id,
+      status: submission.status,
+      policy_results: policyResults.map((r) => ({
+        policy_name: r.policyName,
+        result: r.result,
+        action: r.action,
+        detail: r.detail,
+      })),
+      decided_at: decidedAt,
+      decided_by: decidedBy,
+      created_at: submission.createdAt,
+    };
+
+    if (status === "pending") {
+      response.review_url = `/api/v1/submissions/${submission.id}/reviews`;
+      response.estimated_review_time = "24h";
+    }
+
+    res.status(201).json(response);
+  });
+
+  router.get("/", async (req, res) => {
+    const { status, channel, from, to, limit, offset } = req.query as {
+      status?: string;
+      channel?: string;
+      from?: string;
+      to?: string;
+      limit?: string;
+      offset?: string;
+    };
+
+    const take = Math.min(parseInt(limit ?? "20", 10) || 20, 100);
+    const skip = parseInt(offset ?? "0", 10) || 0;
+
+    const where: Record<string, unknown> = {};
+    if (status) where.status = status;
+    if (channel) where.channel = channel;
+    if (from || to) {
+      const dateFilter: Record<string, Date> = {};
+      if (from) dateFilter.gte = new Date(from);
+      if (to) dateFilter.lte = new Date(to);
+      where.createdAt = dateFilter;
+    }
+
+    const [submissions, total] = await Promise.all([
+      prisma.submission.findMany({
+        where,
+        orderBy: { createdAt: "desc" },
+        take,
+        skip,
+        include: { policyEvaluations: { include: { policy: { select: { name: true } } } } },
+      }),
+      prisma.submission.count({ where }),
+    ]);
+
+    res.json({
+      data: submissions.map((s) => ({
+        id: s.id,
+        channel: s.channel,
+        content_type: s.contentType,
+        status: s.status,
+        created_at: s.createdAt,
+        decided_at: s.decidedAt,
+        policy_results: s.policyEvaluations.map((e) => ({
+          policy_name: e.policy.name,
+          result: e.result,
+          action_taken: e.actionTaken,
+        })),
+      })),
+      total,
+      limit: take,
+      offset: skip,
+    });
+  });
+
+  router.get("/:id", async (req, res) => {
+    const { id } = req.params;
+    if (!UUID_RE.test(id)) {
+      res.status(400).json({ error: "bad_request", message: "Invalid submission ID" });
+      return;
+    }
+
+    const submission = await prisma.submission.findUnique({
+      where: { id },
+      include: {
+        policyEvaluations: { include: { policy: { select: { name: true } } } },
+        reviews: true,
+        feedbacks: true,
+      },
+    });
+
+    if (!submission) {
+      res.status(404).json({ error: "not_found", message: "Submission not found" });
+      return;
+    }
+
+    res.json({
+      id: submission.id,
+      channel: submission.channel,
+      content_type: submission.contentType,
+      content: submission.content,
+      metadata: submission.metadata,
+      status: submission.status,
+      review_mode: submission.reviewMode,
+      callback_url: submission.callbackUrl,
+      created_at: submission.createdAt,
+      decided_at: submission.decidedAt,
+      policy_results: submission.policyEvaluations.map((e) => ({
+        policy_name: e.policy.name,
+        result: e.result,
+        action_taken: e.actionTaken,
+        details: e.details,
+        evaluated_at: e.evaluatedAt,
+      })),
+      reviews: submission.reviews,
+      feedbacks: submission.feedbacks,
+    });
+  });
+
+  return router;
+}
+
+function mapAction(action: string): "pass" | "flag" | "block" {
+  if (action === "block") return "block";
+  if (action === "flag") return "flag";
+  return "pass";
+}


### PR DESCRIPTION
## Summary

Implements issue #5 — core submission API that accepts content, runs it through the policy engine, and returns an instant decision.

- **POST /api/v1/submissions**: Accepts `channel`, `content_type`, `content`, optional `metadata` and `callback_url`. Runs all active, scoped policies in priority order. Returns:
  - `approved` (decided_by: policy) when no policies match
  - `rejected` (decided_by: policy) when any `block` policy matches
  - `pending` with `review_url` and `estimated_review_time` when any `flag` policy matches
- **GET /api/v1/submissions/:id**: Full submission details including policy evaluation results, reviews, and feedbacks
- **GET /api/v1/submissions**: Paginated list with filters (status, channel, date range), capped at 100 per page
- **Policy evaluation storage**: Results stored in `policy_evaluation` table with policy ID, result, action taken, and details
- **Validation**: 400 for missing required fields, 422 for empty content

### Test Evidence
```
Test Files  7 passed (7)
     Tests  97 passed (97)
```

## Test Plan

- [x] `npm run test` — 97 tests pass (7 files)
- [x] `npm run lint` — ESLint + Prettier clean
- [x] `npx tsc --noEmit` — no type errors
- [x] Codex cross-model review in progress

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)