### PR TITLE
feat: post-delivery feedback API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { createApiKeyRouter } from "./routes/api-keys.js";
 import { createPolicyRouter } from "./routes/policies.js";
 import { createSubmissionRouter } from "./routes/submissions.js";
 import { createReviewRouter, createReviewActionsRouter } from "./routes/reviews.js";
+import { createFeedbackRouter } from "./routes/feedback.js";
 import { createWebhookQueue, createWebhookWorker } from "./workers/webhook.js";
 
 const pool = new pg.Pool({ connectionString: config.databaseUrl });
@@ -34,6 +35,7 @@ app.use("/api/v1/api-keys", createApiKeyRouter(prisma));
 app.use("/api/v1/policies", createPolicyRouter(prisma));
 app.use("/api/v1/submissions", createSubmissionRouter(prisma, webhookQueue));
 app.use("/api/v1/submissions", createReviewRouter(prisma, webhookQueue));
+app.use("/api/v1/submissions", createFeedbackRouter(prisma));
 
 async function start(): Promise<void> {
   const worker = createWebhookWorker(prisma, config.redisUrl);

--- a/src/routes/feedback.test.ts
+++ b/src/routes/feedback.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+import { createFeedbackRouter } from "./feedback.js";
+
+const UUID = "00000000-0000-0000-0000-000000000001";
+const UUID2 = "00000000-0000-0000-0000-000000000002";
+
+function buildApp(mockPrisma: Record<string, unknown>) {
+  const prisma = mockPrisma as unknown as Parameters<typeof createFeedbackRouter>[0];
+  const app = express();
+  app.use(express.json());
+  app.use((_req, _res, next) => {
+    _req.apiKey = { id: "api-key-1", name: "test-key" };
+    next();
+  });
+  app.use("/api/v1/submissions", createFeedbackRouter(prisma));
+  return app;
+}
+
+describe("POST /api/v1/submissions/:id/feedback", () => {
+  it("creates positive feedback", async () => {
+    const createFn = vi.fn().mockResolvedValue({
+      id: UUID2,
+      submissionId: UUID,
+      outcome: "positive",
+      reason: null,
+      data: null,
+      createdAt: new Date("2026-01-01"),
+    });
+    const app = buildApp({
+      submission: { findUnique: vi.fn().mockResolvedValue({ id: UUID }) },
+      feedback: { create: createFn },
+    });
+
+    const res = await request(app)
+      .post(`/api/v1/submissions/${UUID}/feedback`)
+      .send({ outcome: "positive" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.outcome).toBe("positive");
+    expect(res.body.submission_id).toBe(UUID);
+    expect(createFn).toHaveBeenCalledOnce();
+  });
+
+  it("creates negative feedback with reason and data", async () => {
+    const createFn = vi.fn().mockResolvedValue({
+      id: UUID2,
+      submissionId: UUID,
+      outcome: "negative",
+      reason: "Customer complained",
+      data: { complaint_id: "C-123" },
+      createdAt: new Date("2026-01-01"),
+    });
+    const app = buildApp({
+      submission: { findUnique: vi.fn().mockResolvedValue({ id: UUID }) },
+      feedback: { create: createFn },
+    });
+
+    const res = await request(app)
+      .post(`/api/v1/submissions/${UUID}/feedback`)
+      .send({
+        outcome: "negative",
+        reason: "Customer complained",
+        data: { complaint_id: "C-123" },
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.outcome).toBe("negative");
+    expect(res.body.reason).toBe("Customer complained");
+    expect(res.body.data).toEqual({ complaint_id: "C-123" });
+  });
+
+  it("creates neutral feedback", async () => {
+    const createFn = vi.fn().mockResolvedValue({
+      id: UUID2,
+      submissionId: UUID,
+      outcome: "neutral",
+      reason: "No impact observed",
+      data: null,
+      createdAt: new Date("2026-01-01"),
+    });
+    const app = buildApp({
+      submission: { findUnique: vi.fn().mockResolvedValue({ id: UUID }) },
+      feedback: { create: createFn },
+    });
+
+    const res = await request(app)
+      .post(`/api/v1/submissions/${UUID}/feedback`)
+      .send({ outcome: "neutral", reason: "No impact observed" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.outcome).toBe("neutral");
+  });
+
+  it("returns 400 for invalid outcome", async () => {
+    const app = buildApp({
+      submission: { findUnique: vi.fn() },
+      feedback: { create: vi.fn() },
+    });
+
+    const res = await request(app)
+      .post(`/api/v1/submissions/${UUID}/feedback`)
+      .send({ outcome: "bad" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain("outcome");
+  });
+
+  it("returns 400 for missing outcome", async () => {
+    const app = buildApp({
+      submission: { findUnique: vi.fn() },
+      feedback: { create: vi.fn() },
+    });
+
+    const res = await request(app).post(`/api/v1/submissions/${UUID}/feedback`).send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain("outcome");
+  });
+
+  it("returns 400 for invalid submission ID format", async () => {
+    const app = buildApp({
+      submission: { findUnique: vi.fn() },
+      feedback: { create: vi.fn() },
+    });
+
+    const res = await request(app)
+      .post("/api/v1/submissions/not-a-uuid/feedback")
+      .send({ outcome: "positive" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain("Invalid submission ID");
+  });
+
+  it("returns 404 for non-existent submission", async () => {
+    const app = buildApp({
+      submission: { findUnique: vi.fn().mockResolvedValue(null) },
+      feedback: { create: vi.fn() },
+    });
+
+    const res = await request(app)
+      .post(`/api/v1/submissions/${UUID}/feedback`)
+      .send({ outcome: "positive" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.message).toContain("Submission not found");
+  });
+
+  it("returns 400 for non-object data", async () => {
+    const app = buildApp({
+      submission: { findUnique: vi.fn().mockResolvedValue({ id: UUID }) },
+      feedback: { create: vi.fn() },
+    });
+
+    const res = await request(app)
+      .post(`/api/v1/submissions/${UUID}/feedback`)
+      .send({ outcome: "positive", data: [1, 2, 3] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain("data must be a JSON object");
+  });
+
+  it("allows multiple feedback on the same submission", async () => {
+    let callCount = 0;
+    const createFn = vi.fn().mockImplementation(() => {
+      callCount++;
+      return Promise.resolve({
+        id: `00000000-0000-0000-0000-00000000000${callCount}`,
+        submissionId: UUID,
+        outcome: callCount === 1 ? "positive" : "negative",
+        reason: null,
+        data: null,
+        createdAt: new Date("2026-01-01"),
+      });
+    });
+    const app = buildApp({
+      submission: { findUnique: vi.fn().mockResolvedValue({ id: UUID }) },
+      feedback: { create: createFn },
+    });
+
+    const res1 = await request(app)
+      .post(`/api/v1/submissions/${UUID}/feedback`)
+      .send({ outcome: "positive" });
+    const res2 = await request(app)
+      .post(`/api/v1/submissions/${UUID}/feedback`)
+      .send({ outcome: "negative" });
+
+    expect(res1.status).toBe(201);
+    expect(res2.status).toBe(201);
+    expect(createFn).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("GET /api/v1/submissions/:id/feedback", () => {
+  it("lists feedback with counts", async () => {
+    const feedbacks = [
+      {
+        id: UUID2,
+        submissionId: UUID,
+        outcome: "positive",
+        reason: null,
+        data: null,
+        createdAt: new Date("2026-01-01"),
+      },
+      {
+        id: "00000000-0000-0000-0000-000000000003",
+        submissionId: UUID,
+        outcome: "negative",
+        reason: "Bad tone",
+        data: null,
+        createdAt: new Date("2026-01-02"),
+      },
+    ];
+    const app = buildApp({
+      submission: { findUnique: vi.fn().mockResolvedValue({ id: UUID }) },
+      feedback: { findMany: vi.fn().mockResolvedValue(feedbacks) },
+    });
+
+    const res = await request(app).get(`/api/v1/submissions/${UUID}/feedback`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.total).toBe(2);
+    expect(res.body.counts).toEqual({ positive: 1, negative: 1, neutral: 0 });
+  });
+
+  it("returns empty list for submission with no feedback", async () => {
+    const app = buildApp({
+      submission: { findUnique: vi.fn().mockResolvedValue({ id: UUID }) },
+      feedback: { findMany: vi.fn().mockResolvedValue([]) },
+    });
+
+    const res = await request(app).get(`/api/v1/submissions/${UUID}/feedback`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(0);
+    expect(res.body.total).toBe(0);
+    expect(res.body.counts).toEqual({ positive: 0, negative: 0, neutral: 0 });
+  });
+
+  it("returns 404 for non-existent submission", async () => {
+    const app = buildApp({
+      submission: { findUnique: vi.fn().mockResolvedValue(null) },
+      feedback: { findMany: vi.fn() },
+    });
+
+    const res = await request(app).get(`/api/v1/submissions/${UUID}/feedback`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.message).toContain("Submission not found");
+  });
+
+  it("returns 400 for invalid submission ID", async () => {
+    const app = buildApp({
+      submission: { findUnique: vi.fn() },
+      feedback: { findMany: vi.fn() },
+    });
+
+    const res = await request(app).get("/api/v1/submissions/not-a-uuid/feedback");
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain("Invalid submission ID");
+  });
+});

--- a/src/routes/feedback.ts
+++ b/src/routes/feedback.ts
@@ -1,0 +1,101 @@
+import { Router } from "express";
+import type { PrismaClient } from "../generated/prisma/client.js";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const VALID_OUTCOMES = ["positive", "negative", "neutral"] as const;
+
+export function createFeedbackRouter(prisma: PrismaClient): Router {
+  const router = Router();
+
+  // POST /api/v1/submissions/:id/feedback — submit post-delivery feedback
+  router.post("/:id/feedback", async (req, res) => {
+    const { id } = req.params;
+    if (!UUID_RE.test(id)) {
+      res.status(400).json({ error: "bad_request", message: "Invalid submission ID" });
+      return;
+    }
+
+    const { outcome, reason, data } = req.body as {
+      outcome?: string;
+      reason?: string;
+      data?: Record<string, unknown>;
+    };
+
+    if (!outcome || !VALID_OUTCOMES.includes(outcome as (typeof VALID_OUTCOMES)[number])) {
+      res.status(400).json({
+        error: "bad_request",
+        message: `outcome must be one of: ${VALID_OUTCOMES.join(", ")}`,
+      });
+      return;
+    }
+
+    if (data !== undefined && (typeof data !== "object" || Array.isArray(data))) {
+      res.status(400).json({ error: "bad_request", message: "data must be a JSON object" });
+      return;
+    }
+
+    const submission = await prisma.submission.findUnique({ where: { id } });
+    if (!submission) {
+      res.status(404).json({ error: "not_found", message: "Submission not found" });
+      return;
+    }
+
+    const feedback = await prisma.feedback.create({
+      data: {
+        submissionId: id,
+        outcome: outcome as "positive" | "negative" | "neutral",
+        reason: reason ?? null,
+        data: data ? (data as object) : undefined,
+      },
+    });
+
+    res.status(201).json({
+      id: feedback.id,
+      submission_id: feedback.submissionId,
+      outcome: feedback.outcome,
+      reason: feedback.reason,
+      data: feedback.data,
+      created_at: feedback.createdAt,
+    });
+  });
+
+  // GET /api/v1/submissions/:id/feedback — list feedback for a submission
+  router.get("/:id/feedback", async (req, res) => {
+    const { id } = req.params;
+    if (!UUID_RE.test(id)) {
+      res.status(400).json({ error: "bad_request", message: "Invalid submission ID" });
+      return;
+    }
+
+    const submission = await prisma.submission.findUnique({ where: { id } });
+    if (!submission) {
+      res.status(404).json({ error: "not_found", message: "Submission not found" });
+      return;
+    }
+
+    const feedbacks = await prisma.feedback.findMany({
+      where: { submissionId: id },
+      orderBy: { createdAt: "desc" },
+    });
+
+    const counts = { positive: 0, negative: 0, neutral: 0 };
+    for (const f of feedbacks) {
+      counts[f.outcome]++;
+    }
+
+    res.json({
+      data: feedbacks.map((f) => ({
+        id: f.id,
+        submission_id: f.submissionId,
+        outcome: f.outcome,
+        reason: f.reason,
+        data: f.data,
+        created_at: f.createdAt,
+      })),
+      total: feedbacks.length,
+      counts,
+    });
+  });
+
+  return router;
+}


### PR DESCRIPTION
Closes #8

## Summary

- **POST /api/v1/submissions/:id/feedback** — submit post-delivery feedback (positive/negative/neutral outcome, optional reason and data)
- **GET /api/v1/submissions/:id/feedback** — list feedback entries with aggregate counts per outcome
- Multiple feedback entries allowed per submission
- Feedback already included in `GET /api/v1/submissions/:id` response (via existing Prisma relation)

## Files changed

| File | Change |
|------|--------|
| `src/routes/feedback.ts` | New: feedback create + list endpoints |
| `src/routes/feedback.test.ts` | New: 13 tests covering create, list, validation, edge cases |
| `src/index.ts` | Wire feedback router into app |

## Test evidence

```
 Test Files  10 passed (10)
      Tests  136 passed (136)
   Duration  2.30s
```

TypeScript: ✅ no errors
ESLint: ✅ clean
Prettier: ✅ formatted

## Test plan

- [x] Create positive feedback — returns 201
- [x] Create negative feedback with reason and data
- [x] Create neutral feedback
- [x] Invalid outcome — returns 400
- [x] Missing outcome — returns 400
- [x] Invalid submission ID format — returns 400
- [x] Non-existent submission — returns 404
- [x] Invalid data (array) — returns 400
- [x] Multiple feedback on same submission
- [x] List feedback with aggregate counts
- [x] Empty feedback list
- [x] List 404 for non-existent submission
- [x] List 400 for invalid ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)