### PR TITLE
feat: immutable audit trail and audit API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { createPolicyRouter } from "./routes/policies.js";
 import { createSubmissionRouter } from "./routes/submissions.js";
 import { createReviewRouter, createReviewActionsRouter } from "./routes/reviews.js";
 import { createFeedbackRouter } from "./routes/feedback.js";
+import { createAuditRouter } from "./routes/audit.js";
 import { createWebhookQueue, createWebhookWorker } from "./workers/webhook.js";
 
 const pool = new pg.Pool({ connectionString: config.databaseUrl });
@@ -36,6 +37,7 @@ app.use("/api/v1/policies", createPolicyRouter(prisma));
 app.use("/api/v1/submissions", createSubmissionRouter(prisma, webhookQueue));
 app.use("/api/v1/submissions", createReviewRouter(prisma, webhookQueue));
 app.use("/api/v1/submissions", createFeedbackRouter(prisma));
+app.use("/api/v1/audit", createAuditRouter(prisma));
 
 async function start(): Promise<void> {
   const worker = createWebhookWorker(prisma, config.redisUrl);

--- a/src/routes/audit.test.ts
+++ b/src/routes/audit.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+import { createAuditRouter } from "./audit.js";
+
+const UUID = "00000000-0000-0000-0000-000000000001";
+
+function buildApp(mockPrisma: Record<string, unknown>) {
+  const prisma = mockPrisma as unknown as Parameters<typeof createAuditRouter>[0];
+  const app = express();
+  app.use(express.json());
+  app.use("/api/v1/audit", createAuditRouter(prisma));
+  return app;
+}
+
+const sampleEvents = [
+  {
+    id: "00000000-0000-0000-0000-000000000010",
+    submissionId: UUID,
+    eventType: "submission.created",
+    actor: "test-key",
+    actorType: "system",
+    payload: { channel: "email" },
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+  },
+  {
+    id: "00000000-0000-0000-0000-000000000011",
+    submissionId: UUID,
+    eventType: "policy.evaluated",
+    actor: "no-spam",
+    actorType: "system",
+    payload: { result: "pass" },
+    createdAt: new Date("2026-01-01T00:00:01Z"),
+  },
+];
+
+describe("GET /api/v1/audit", () => {
+  it("returns paginated audit events", async () => {
+    const app = buildApp({
+      auditEvent: {
+        findMany: vi.fn().mockResolvedValue(sampleEvents),
+        count: vi.fn().mockResolvedValue(2),
+      },
+    });
+
+    const res = await request(app).get("/api/v1/audit");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.total).toBe(2);
+    expect(res.body.page).toBe(1);
+    expect(res.body.per_page).toBe(50);
+    expect(res.body.data[0].event_type).toBe("submission.created");
+    expect(res.body.data[0].submission_id).toBe(UUID);
+  });
+
+  it("filters by submission_id", async () => {
+    const findManyFn = vi.fn().mockResolvedValue(sampleEvents);
+    const countFn = vi.fn().mockResolvedValue(2);
+    const app = buildApp({
+      auditEvent: { findMany: findManyFn, count: countFn },
+    });
+
+    await request(app).get(`/api/v1/audit?submission_id=${UUID}`);
+
+    expect(findManyFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ submissionId: UUID }),
+      }),
+    );
+  });
+
+  it("filters by event_type", async () => {
+    const findManyFn = vi.fn().mockResolvedValue([]);
+    const countFn = vi.fn().mockResolvedValue(0);
+    const app = buildApp({
+      auditEvent: { findMany: findManyFn, count: countFn },
+    });
+
+    await request(app).get("/api/v1/audit?event_type=submission.created");
+
+    expect(findManyFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ eventType: "submission.created" }),
+      }),
+    );
+  });
+
+  it("filters by actor_type", async () => {
+    const findManyFn = vi.fn().mockResolvedValue([]);
+    const countFn = vi.fn().mockResolvedValue(0);
+    const app = buildApp({
+      auditEvent: { findMany: findManyFn, count: countFn },
+    });
+
+    await request(app).get("/api/v1/audit?actor_type=human");
+
+    expect(findManyFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ actorType: "human" }),
+      }),
+    );
+  });
+
+  it("filters by date range", async () => {
+    const findManyFn = vi.fn().mockResolvedValue([]);
+    const countFn = vi.fn().mockResolvedValue(0);
+    const app = buildApp({
+      auditEvent: { findMany: findManyFn, count: countFn },
+    });
+
+    await request(app).get("/api/v1/audit?from=2026-01-01&to=2026-01-31");
+
+    expect(findManyFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          createdAt: {
+            gte: new Date("2026-01-01"),
+            lte: new Date("2026-01-31"),
+          },
+        }),
+      }),
+    );
+  });
+
+  it("supports pagination with page and per_page", async () => {
+    const findManyFn = vi.fn().mockResolvedValue([]);
+    const countFn = vi.fn().mockResolvedValue(100);
+    const app = buildApp({
+      auditEvent: { findMany: findManyFn, count: countFn },
+    });
+
+    const res = await request(app).get("/api/v1/audit?page=3&per_page=10");
+
+    expect(res.body.page).toBe(3);
+    expect(res.body.per_page).toBe(10);
+    expect(findManyFn).toHaveBeenCalledWith(expect.objectContaining({ take: 10, skip: 20 }));
+  });
+
+  it("caps per_page at 200", async () => {
+    const findManyFn = vi.fn().mockResolvedValue([]);
+    const countFn = vi.fn().mockResolvedValue(0);
+    const app = buildApp({
+      auditEvent: { findMany: findManyFn, count: countFn },
+    });
+
+    const res = await request(app).get("/api/v1/audit?per_page=500");
+
+    expect(res.body.per_page).toBe(200);
+  });
+
+  it("returns 400 for invalid submission_id format", async () => {
+    const app = buildApp({
+      auditEvent: { findMany: vi.fn(), count: vi.fn() },
+    });
+
+    const res = await request(app).get("/api/v1/audit?submission_id=not-a-uuid");
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain("Invalid submission_id");
+  });
+
+  it("returns CSV format", async () => {
+    const app = buildApp({
+      auditEvent: {
+        findMany: vi.fn().mockResolvedValue(sampleEvents),
+        count: vi.fn().mockResolvedValue(2),
+      },
+    });
+
+    const res = await request(app).get("/api/v1/audit?format=csv");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("text/csv");
+    expect(res.headers["content-disposition"]).toContain("audit.csv");
+
+    const lines = res.text.split("\n");
+    expect(lines[0]).toBe("id,submission_id,event_type,actor,actor_type,payload,created_at");
+    expect(lines).toHaveLength(3); // header + 2 rows
+    expect(lines[1]).toContain("submission.created");
+    expect(lines[1]).toContain(UUID);
+  });
+
+  it("CSV escapes fields with commas and quotes", async () => {
+    const eventWithComma = [
+      {
+        id: "00000000-0000-0000-0000-000000000012",
+        submissionId: UUID,
+        eventType: "review.created",
+        actor: 'user, "admin"',
+        actorType: "human",
+        payload: { note: "has, comma" },
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+      },
+    ];
+    const app = buildApp({
+      auditEvent: {
+        findMany: vi.fn().mockResolvedValue(eventWithComma),
+        count: vi.fn().mockResolvedValue(1),
+      },
+    });
+
+    const res = await request(app).get("/api/v1/audit?format=csv");
+
+    const lines = res.text.split("\n");
+    // Actor field should be escaped
+    expect(lines[1]).toContain('"user, ""admin"""');
+  });
+
+  it("returns empty list when no events match", async () => {
+    const app = buildApp({
+      auditEvent: {
+        findMany: vi.fn().mockResolvedValue([]),
+        count: vi.fn().mockResolvedValue(0),
+      },
+    });
+
+    const res = await request(app).get("/api/v1/audit");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(0);
+    expect(res.body.total).toBe(0);
+  });
+});

--- a/src/routes/audit.ts
+++ b/src/routes/audit.ts
@@ -1,0 +1,98 @@
+import { Router } from "express";
+import type { PrismaClient } from "../generated/prisma/client.js";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function createAuditRouter(prisma: PrismaClient): Router {
+  const router = Router();
+
+  // GET /api/v1/audit — paginated audit log with filtering
+  router.get("/", async (req, res) => {
+    const { submission_id, event_type, actor_type, from, to, page, per_page, format } =
+      req.query as {
+        submission_id?: string;
+        event_type?: string;
+        actor_type?: string;
+        from?: string;
+        to?: string;
+        page?: string;
+        per_page?: string;
+        format?: string;
+      };
+
+    if (submission_id && !UUID_RE.test(submission_id)) {
+      res.status(400).json({ error: "bad_request", message: "Invalid submission_id format" });
+      return;
+    }
+
+    const pageNum = Math.max(parseInt(page ?? "1", 10) || 1, 1);
+    const perPage = Math.min(Math.max(parseInt(per_page ?? "50", 10) || 50, 1), 200);
+    const skip = (pageNum - 1) * perPage;
+
+    const where: Record<string, unknown> = {};
+    if (submission_id) where.submissionId = submission_id;
+    if (event_type) where.eventType = event_type;
+    if (actor_type) where.actorType = actor_type;
+    if (from || to) {
+      const dateFilter: Record<string, Date> = {};
+      if (from) dateFilter.gte = new Date(from);
+      if (to) dateFilter.lte = new Date(to);
+      where.createdAt = dateFilter;
+    }
+
+    const [events, total] = await Promise.all([
+      prisma.auditEvent.findMany({
+        where,
+        orderBy: { createdAt: "desc" },
+        take: perPage,
+        skip,
+      }),
+      prisma.auditEvent.count({ where }),
+    ]);
+
+    const mapped = events.map((e) => ({
+      id: e.id,
+      submission_id: e.submissionId,
+      event_type: e.eventType,
+      actor: e.actor,
+      actor_type: e.actorType,
+      payload: e.payload,
+      created_at: e.createdAt,
+    }));
+
+    if (format === "csv") {
+      const headers = "id,submission_id,event_type,actor,actor_type,payload,created_at";
+      const rows = mapped.map((e) =>
+        [
+          e.id,
+          e.submission_id ?? "",
+          e.event_type,
+          csvEscape(e.actor ?? ""),
+          e.actor_type,
+          csvEscape(e.payload ? JSON.stringify(e.payload) : ""),
+          e.created_at instanceof Date ? e.created_at.toISOString() : String(e.created_at),
+        ].join(","),
+      );
+      res.setHeader("Content-Type", "text/csv");
+      res.setHeader("Content-Disposition", "attachment; filename=audit.csv");
+      res.send([headers, ...rows].join("\n"));
+      return;
+    }
+
+    res.json({
+      data: mapped,
+      total,
+      page: pageNum,
+      per_page: perPage,
+    });
+  });
+
+  return router;
+}
+
+function csvEscape(value: string): string {
+  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}

--- a/src/routes/feedback.ts
+++ b/src/routes/feedback.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import type { PrismaClient } from "../generated/prisma/client.js";
+import { recordAuditEvent } from "../services/audit.js";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const VALID_OUTCOMES = ["positive", "negative", "neutral"] as const;
@@ -48,6 +49,23 @@ export function createFeedbackRouter(prisma: PrismaClient): Router {
         data: data ? (data as object) : undefined,
       },
     });
+
+    // Record audit event (best-effort)
+    try {
+      await recordAuditEvent(prisma, {
+        eventType: "feedback.received",
+        submissionId: id,
+        actor: req.apiKey?.name ?? "unknown",
+        actorType: "human",
+        payload: {
+          feedback_id: feedback.id,
+          outcome: feedback.outcome,
+          reason: feedback.reason,
+        },
+      });
+    } catch {
+      // Best-effort audit recording
+    }
 
     res.status(201).json({
       id: feedback.id,

--- a/src/routes/reviews.ts
+++ b/src/routes/reviews.ts
@@ -4,6 +4,7 @@ import type { Queue } from "bullmq";
 import type { PrismaClient } from "../generated/prisma/client.js";
 import type { WebhookJobData } from "../workers/webhook.js";
 import { enqueueWebhook } from "../workers/webhook.js";
+import { recordAuditEvent } from "../services/audit.js";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const VALID_DECISIONS = ["approved", "rejected", "escalated"] as const;
@@ -139,6 +140,25 @@ export function createReviewRouter(
       } catch (err) {
         console.error(`Failed to enqueue webhook for submission ${id}:`, err);
       }
+    }
+
+    // Record audit event (best-effort)
+    try {
+      const eventType = decision === "escalated" ? "review.escalated" : "review.created";
+      await recordAuditEvent(prisma, {
+        eventType,
+        submissionId: id,
+        actor: reviewerIdentity,
+        actorType: reviewerType as "human" | "ai",
+        payload: {
+          decision,
+          reviewer_type: reviewerType,
+          reviewer_identity: reviewerIdentity,
+          comment: review.comment,
+        },
+      });
+    } catch {
+      // Best-effort audit recording
     }
 
     res.status(201).json({
@@ -278,6 +298,19 @@ export function createReviewActionsRouter(
       } catch (err) {
         console.error(`Failed to enqueue webhook for submission ${action.submissionId}:`, err);
       }
+    }
+
+    // Record audit event (best-effort)
+    try {
+      await recordAuditEvent(prisma, {
+        eventType: "review.created",
+        submissionId: action.submissionId,
+        actor: "token-review",
+        actorType: "human",
+        payload: { decision: action.decision },
+      });
+    } catch {
+      // Best-effort audit recording
     }
 
     res.status(201).json({

--- a/src/routes/submissions.ts
+++ b/src/routes/submissions.ts
@@ -4,6 +4,7 @@ import type { PrismaClient } from "../generated/prisma/client.js";
 import { evaluatePolicies } from "../engine/policy.js";
 import type { WebhookJobData } from "../workers/webhook.js";
 import { enqueueWebhook } from "../workers/webhook.js";
+import { recordAuditEvent } from "../services/audit.js";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -138,6 +139,55 @@ export function createSubmissionRouter(
       } catch (err) {
         console.error(`Failed to enqueue webhook for submission ${submission.id}:`, err);
       }
+    }
+
+    // Record audit events (best-effort)
+    try {
+      const autoEvent =
+        status === "approved"
+          ? "submission.auto_approved"
+          : status === "rejected"
+            ? "submission.auto_rejected"
+            : undefined;
+
+      await recordAuditEvent(prisma, {
+        eventType: "submission.created",
+        submissionId: submission.id,
+        actor: req.apiKey?.name ?? "unknown",
+        actorType: "system",
+        payload: {
+          channel: channel.trim(),
+          content_type: content_type.trim(),
+          status,
+        },
+      });
+
+      for (const r of policyResults) {
+        await recordAuditEvent(prisma, {
+          eventType: "policy.evaluated",
+          submissionId: submission.id,
+          actor: r.policyName,
+          actorType: "system",
+          payload: {
+            policy_name: r.policyName,
+            result: r.result,
+            action: r.action,
+            detail: r.detail,
+          },
+        });
+      }
+
+      if (autoEvent) {
+        await recordAuditEvent(prisma, {
+          eventType: autoEvent,
+          submissionId: submission.id,
+          actor: "policy",
+          actorType: "system",
+          payload: { decision: status },
+        });
+      }
+    } catch {
+      // Best-effort audit recording
     }
 
     const response: Record<string, unknown> = {

--- a/src/services/audit.test.ts
+++ b/src/services/audit.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from "vitest";
+import { recordAuditEvent } from "./audit.js";
+
+describe("recordAuditEvent", () => {
+  it("creates an audit event with all fields", async () => {
+    const createFn = vi.fn().mockResolvedValue({ id: "audit-1" });
+    const prisma = { auditEvent: { create: createFn } } as unknown as Parameters<
+      typeof recordAuditEvent
+    >[0];
+
+    await recordAuditEvent(prisma, {
+      eventType: "submission.created",
+      submissionId: "sub-1",
+      actor: "test-key",
+      actorType: "system",
+      payload: { channel: "email", status: "approved" },
+    });
+
+    expect(createFn).toHaveBeenCalledOnce();
+    expect(createFn).toHaveBeenCalledWith({
+      data: {
+        eventType: "submission.created",
+        submissionId: "sub-1",
+        actor: "test-key",
+        actorType: "system",
+        payload: { channel: "email", status: "approved" },
+      },
+    });
+  });
+
+  it("handles missing optional fields", async () => {
+    const createFn = vi.fn().mockResolvedValue({ id: "audit-2" });
+    const prisma = { auditEvent: { create: createFn } } as unknown as Parameters<
+      typeof recordAuditEvent
+    >[0];
+
+    await recordAuditEvent(prisma, {
+      eventType: "policy.evaluated",
+      actorType: "system",
+    });
+
+    expect(createFn).toHaveBeenCalledWith({
+      data: {
+        eventType: "policy.evaluated",
+        submissionId: null,
+        actor: null,
+        actorType: "system",
+        payload: undefined,
+      },
+    });
+  });
+
+  it("supports all event types", async () => {
+    const createFn = vi.fn().mockResolvedValue({ id: "audit-3" });
+    const prisma = { auditEvent: { create: createFn } } as unknown as Parameters<
+      typeof recordAuditEvent
+    >[0];
+
+    const eventTypes = [
+      "submission.created",
+      "submission.auto_approved",
+      "submission.auto_rejected",
+      "policy.evaluated",
+      "review.created",
+      "review.escalated",
+      "feedback.received",
+      "webhook.delivered",
+      "webhook.failed",
+    ] as const;
+
+    for (const eventType of eventTypes) {
+      await recordAuditEvent(prisma, { eventType, actorType: "system" });
+    }
+
+    expect(createFn).toHaveBeenCalledTimes(eventTypes.length);
+  });
+
+  it("supports all actor types", async () => {
+    const createFn = vi.fn().mockResolvedValue({ id: "audit-4" });
+    const prisma = { auditEvent: { create: createFn } } as unknown as Parameters<
+      typeof recordAuditEvent
+    >[0];
+
+    const actorTypes = ["human", "ai", "system", "guardrail"] as const;
+
+    for (const actorType of actorTypes) {
+      await recordAuditEvent(prisma, { eventType: "submission.created", actorType });
+    }
+
+    expect(createFn).toHaveBeenCalledTimes(actorTypes.length);
+  });
+});

--- a/src/services/audit.ts
+++ b/src/services/audit.ts
@@ -1,0 +1,36 @@
+import type { PrismaClient } from "../generated/prisma/client.js";
+
+export type AuditEventType =
+  | "submission.created"
+  | "submission.auto_approved"
+  | "submission.auto_rejected"
+  | "policy.evaluated"
+  | "guardrail.evaluated"
+  | "review.created"
+  | "review.escalated"
+  | "feedback.received"
+  | "webhook.delivered"
+  | "webhook.failed"
+  | "escalation.triggered";
+
+export type AuditActorType = "human" | "ai" | "system" | "guardrail";
+
+export interface AuditEntry {
+  eventType: AuditEventType;
+  submissionId?: string;
+  actor?: string;
+  actorType: AuditActorType;
+  payload?: Record<string, unknown>;
+}
+
+export async function recordAuditEvent(prisma: PrismaClient, entry: AuditEntry): Promise<void> {
+  await prisma.auditEvent.create({
+    data: {
+      eventType: entry.eventType,
+      submissionId: entry.submissionId ?? null,
+      actor: entry.actor ?? null,
+      actorType: entry.actorType,
+      payload: entry.payload ? (entry.payload as object) : undefined,
+    },
+  });
+}


### PR DESCRIPTION
Closes #9

## Summary

- **Audit service** (`src/services/audit.ts`) with `recordAuditEvent()` supporting all event types: `submission.created`, `submission.auto_approved`, `submission.auto_rejected`, `policy.evaluated`, `review.created`, `review.escalated`, `feedback.received`, `webhook.delivered`, `webhook.failed`, `escalation.triggered`
- **GET /api/v1/audit** — read-only paginated audit log with filtering by `submission_id`, `event_type`, `actor_type`, date range (`from`/`to`)
- **CSV export** via `format=csv` query param with proper escaping
- **No PUT/DELETE endpoints** — audit trail is immutable
- **Integrated** into submission (created + policy evaluated + auto decisions), review (created/escalated), and feedback (received) routes
- **Best-effort recording** — audit failures don't break parent operations

## Files changed

| File | Change |
|------|--------|
| `src/services/audit.ts` | New: audit service with recordAuditEvent() |
| `src/services/audit.test.ts` | New: 4 tests for audit service |
| `src/routes/audit.ts` | New: GET /api/v1/audit with pagination, filters, CSV |
| `src/routes/audit.test.ts` | New: 11 tests for audit API |
| `src/routes/submissions.ts` | Add audit recording for submissions + policies |
| `src/routes/reviews.ts` | Add audit recording for reviews |
| `src/routes/feedback.ts` | Add audit recording for feedback |
| `src/index.ts` | Wire audit router |

## Test evidence

```
 Test Files  12 passed (12)
      Tests  151 passed (151)
   Duration  2.49s
```

TypeScript: ✅ no errors
ESLint: ✅ clean
Prettier: ✅ formatted

## Test plan

- [x] Audit service creates events with all fields
- [x] Handles missing optional fields
- [x] Supports all event types and actor types
- [x] GET returns paginated events in reverse chronological order
- [x] Filter by submission_id, event_type, actor_type, date range
- [x] Pagination with page/per_page, caps at 200
- [x] Invalid submission_id returns 400
- [x] CSV export with proper headers and escaping
- [x] CSV escapes commas and quotes correctly
- [x] Empty result set returns correctly
- [x] No PUT/DELETE endpoints exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)