### PR TITLE
feat: guardrail adapter registry and evaluation pipeline

### DIFF
--- a/src/engine/guardrail.test.ts
+++ b/src/engine/guardrail.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { evaluateGuardrails } from "./guardrail.js";
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const UUID1 = "00000000-0000-0000-0000-000000000001";
+const UUID2 = "00000000-0000-0000-0000-000000000002";
+const UUID3 = "00000000-0000-0000-0000-000000000003";
+
+const baseInput = {
+  submissionId: "sub-1",
+  content: "test content",
+  metadata: {},
+  channel: "email",
+  contentType: "text/plain",
+};
+
+function mockPrisma(guardrails: Record<string, unknown>[]) {
+  return {
+    guardrail: {
+      findMany: vi.fn().mockResolvedValue(guardrails),
+    },
+    guardrailEvaluation: {
+      create: vi.fn().mockResolvedValue({}),
+    },
+    auditEvent: {
+      create: vi.fn().mockResolvedValue({}),
+    },
+  } as unknown as Parameters<typeof evaluateGuardrails>[0];
+}
+
+function makeGuardrail(overrides: Record<string, unknown> = {}) {
+  return {
+    id: UUID1,
+    name: "test-guardrail",
+    endpointUrl: "https://guardrail.test/evaluate",
+    timeoutMs: 10000,
+    failureMode: "fail_closed",
+    pipelineOrder: 1,
+    scopeChannel: null,
+    scopeContentType: null,
+    active: true,
+    ...overrides,
+  };
+}
+
+describe("evaluateGuardrails", () => {
+  it("returns empty array when no guardrails are registered", async () => {
+    const prisma = mockPrisma([]);
+    const results = await evaluateGuardrails(prisma, baseInput);
+    expect(results).toEqual([]);
+  });
+
+  it("evaluates a passing guardrail", async () => {
+    server.use(
+      http.post("https://guardrail.test/evaluate", () =>
+        HttpResponse.json({ verdict: "pass", confidence: 0.99, reasoning: "Content is safe" }),
+      ),
+    );
+
+    const prisma = mockPrisma([makeGuardrail()]);
+    const results = await evaluateGuardrails(prisma, baseInput);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].verdict).toBe("pass");
+    expect(results[0].confidence).toBe(0.99);
+    expect(results[0].reasoning).toBe("Content is safe");
+    expect(results[0].guardrailName).toBe("test-guardrail");
+    expect(results[0].latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("evaluates a failing guardrail", async () => {
+    server.use(
+      http.post("https://guardrail.test/evaluate", () =>
+        HttpResponse.json({
+          verdict: "fail",
+          confidence: 0.95,
+          reasoning: "Contains harmful content",
+          categories: ["toxicity"],
+        }),
+      ),
+    );
+
+    const prisma = mockPrisma([makeGuardrail()]);
+    const results = await evaluateGuardrails(prisma, baseInput);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].verdict).toBe("fail");
+    expect(results[0].categories).toEqual(["toxicity"]);
+  });
+
+  it("evaluates a flagging guardrail", async () => {
+    server.use(
+      http.post("https://guardrail.test/evaluate", () =>
+        HttpResponse.json({ verdict: "flag", confidence: 0.6, reasoning: "Uncertain" }),
+      ),
+    );
+
+    const prisma = mockPrisma([makeGuardrail()]);
+    const results = await evaluateGuardrails(prisma, baseInput);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].verdict).toBe("flag");
+  });
+
+  it("evaluates multiple guardrails in pipeline order", async () => {
+    let callOrder: string[] = [];
+
+    server.use(
+      http.post("https://guardrail.test/first", () => {
+        callOrder.push("first");
+        return HttpResponse.json({ verdict: "pass" });
+      }),
+      http.post("https://guardrail.test/second", () => {
+        callOrder.push("second");
+        return HttpResponse.json({ verdict: "pass" });
+      }),
+    );
+
+    const prisma = mockPrisma([
+      makeGuardrail({
+        id: UUID1,
+        name: "first",
+        endpointUrl: "https://guardrail.test/first",
+        pipelineOrder: 1,
+      }),
+      makeGuardrail({
+        id: UUID2,
+        name: "second",
+        endpointUrl: "https://guardrail.test/second",
+        pipelineOrder: 2,
+      }),
+    ]);
+
+    const results = await evaluateGuardrails(prisma, baseInput);
+
+    expect(results).toHaveLength(2);
+    expect(callOrder).toEqual(["first", "second"]);
+  });
+
+  it("short-circuits on fail_closed failure", async () => {
+    let secondCalled = false;
+
+    server.use(
+      http.post("https://guardrail.test/first", () => HttpResponse.json({ verdict: "fail" })),
+      http.post("https://guardrail.test/second", () => {
+        secondCalled = true;
+        return HttpResponse.json({ verdict: "pass" });
+      }),
+    );
+
+    const prisma = mockPrisma([
+      makeGuardrail({
+        id: UUID1,
+        name: "blocker",
+        endpointUrl: "https://guardrail.test/first",
+        failureMode: "fail_closed",
+        pipelineOrder: 1,
+      }),
+      makeGuardrail({
+        id: UUID2,
+        name: "second",
+        endpointUrl: "https://guardrail.test/second",
+        failureMode: "fail_closed",
+        pipelineOrder: 2,
+      }),
+    ]);
+
+    const results = await evaluateGuardrails(prisma, baseInput);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].verdict).toBe("fail");
+    expect(secondCalled).toBe(false);
+  });
+
+  it("continues pipeline on fail_open failure", async () => {
+    server.use(
+      http.post("https://guardrail.test/first", () => HttpResponse.json({ verdict: "fail" })),
+      http.post("https://guardrail.test/second", () => HttpResponse.json({ verdict: "pass" })),
+    );
+
+    const prisma = mockPrisma([
+      makeGuardrail({
+        id: UUID1,
+        name: "lenient",
+        endpointUrl: "https://guardrail.test/first",
+        failureMode: "fail_open",
+        pipelineOrder: 1,
+      }),
+      makeGuardrail({
+        id: UUID2,
+        name: "second",
+        endpointUrl: "https://guardrail.test/second",
+        failureMode: "fail_open",
+        pipelineOrder: 2,
+      }),
+    ]);
+
+    const results = await evaluateGuardrails(prisma, baseInput);
+
+    expect(results).toHaveLength(2);
+    expect(results[0].verdict).toBe("fail");
+    expect(results[1].verdict).toBe("pass");
+  });
+
+  it("applies fail_closed on adapter error", async () => {
+    server.use(
+      http.post("https://guardrail.test/evaluate", () =>
+        HttpResponse.json({ error: "internal" }, { status: 500 }),
+      ),
+    );
+
+    const prisma = mockPrisma([makeGuardrail({ failureMode: "fail_closed" })]);
+    const results = await evaluateGuardrails(prisma, baseInput);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].verdict).toBe("fail");
+    expect(results[0].error).toContain("status 500");
+  });
+
+  it("applies fail_open on adapter error", async () => {
+    server.use(
+      http.post("https://guardrail.test/evaluate", () =>
+        HttpResponse.json({ error: "internal" }, { status: 500 }),
+      ),
+    );
+
+    const prisma = mockPrisma([makeGuardrail({ failureMode: "fail_open" })]);
+    const results = await evaluateGuardrails(prisma, baseInput);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].verdict).toBe("pass");
+    expect(results[0].error).toContain("status 500");
+  });
+
+  it("applies failure mode on timeout", async () => {
+    server.use(
+      http.post("https://guardrail.test/evaluate", async () => {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        return HttpResponse.json({ verdict: "pass" });
+      }),
+    );
+
+    const prisma = mockPrisma([makeGuardrail({ timeoutMs: 50, failureMode: "fail_closed" })]);
+    const results = await evaluateGuardrails(prisma, baseInput);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].verdict).toBe("fail");
+    expect(results[0].error).toBeDefined();
+  });
+
+  it("records audit events for each evaluation", async () => {
+    server.use(
+      http.post("https://guardrail.test/evaluate", () => HttpResponse.json({ verdict: "pass" })),
+    );
+
+    const prisma = mockPrisma([makeGuardrail()]);
+    await evaluateGuardrails(prisma, baseInput);
+
+    expect(prisma.auditEvent.create).toHaveBeenCalledOnce();
+    expect(prisma.auditEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        eventType: "guardrail.evaluated",
+        actorType: "guardrail",
+      }),
+    });
+  });
+
+  it("sends correct payload to adapter endpoint", async () => {
+    let receivedBody: Record<string, unknown> = {};
+
+    server.use(
+      http.post("https://guardrail.test/evaluate", async ({ request }) => {
+        receivedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ verdict: "pass" });
+      }),
+    );
+
+    const prisma = mockPrisma([makeGuardrail()]);
+    await evaluateGuardrails(prisma, {
+      ...baseInput,
+      content: "hello world",
+      metadata: { key: "value" },
+    });
+
+    expect(receivedBody.submission_id).toBe("sub-1");
+    expect(receivedBody.content).toBe("hello world");
+    expect(receivedBody.metadata).toEqual({ key: "value" });
+    expect(receivedBody.channel).toBe("email");
+    expect(receivedBody.content_type).toBe("text/plain");
+  });
+});

--- a/src/engine/guardrail.ts
+++ b/src/engine/guardrail.ts
@@ -1,0 +1,145 @@
+import type { PrismaClient } from "../generated/prisma/client.js";
+import { recordAuditEvent } from "../services/audit.js";
+
+export interface GuardrailInput {
+  submissionId: string;
+  content: string;
+  metadata: Record<string, unknown>;
+  channel: string;
+  contentType: string;
+}
+
+export interface GuardrailResult {
+  guardrailId: string;
+  guardrailName: string;
+  verdict: "pass" | "fail" | "flag";
+  confidence: number | null;
+  reasoning: string | null;
+  categories: string[] | null;
+  latencyMs: number;
+  failureMode: string;
+  error?: string;
+}
+
+interface AdapterResponse {
+  verdict: "pass" | "fail" | "flag";
+  confidence?: number;
+  reasoning?: string;
+  categories?: string[];
+}
+
+const MAX_TIMEOUT_MS = 30000;
+
+export async function evaluateGuardrails(
+  prisma: PrismaClient,
+  input: GuardrailInput,
+): Promise<GuardrailResult[]> {
+  const guardrails = await prisma.guardrail.findMany({
+    where: {
+      active: true,
+      OR: [
+        { scopeChannel: null, scopeContentType: null },
+        { scopeChannel: input.channel, scopeContentType: null },
+        { scopeChannel: null, scopeContentType: input.contentType },
+        { scopeChannel: input.channel, scopeContentType: input.contentType },
+      ],
+    },
+    orderBy: { pipelineOrder: "asc" },
+  });
+
+  const results: GuardrailResult[] = [];
+
+  for (const guardrail of guardrails) {
+    const timeoutMs = Math.min(guardrail.timeoutMs, MAX_TIMEOUT_MS);
+    const start = Date.now();
+    let result: GuardrailResult;
+
+    try {
+      const resp = await fetch(guardrail.endpointUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          submission_id: input.submissionId,
+          content: input.content,
+          metadata: input.metadata,
+          channel: input.channel,
+          content_type: input.contentType,
+        }),
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+
+      if (!resp.ok) {
+        throw new Error(`Adapter returned status ${resp.status}`);
+      }
+
+      const body = (await resp.json()) as AdapterResponse;
+      const latencyMs = Date.now() - start;
+
+      const verdict = validateVerdict(body.verdict);
+
+      result = {
+        guardrailId: guardrail.id,
+        guardrailName: guardrail.name,
+        verdict,
+        confidence: body.confidence ?? null,
+        reasoning: body.reasoning ?? null,
+        categories: body.categories ?? null,
+        latencyMs,
+        failureMode: guardrail.failureMode,
+      };
+    } catch (err) {
+      const latencyMs = Date.now() - start;
+      const errorMsg = err instanceof Error ? err.message : String(err);
+
+      // Apply failure mode
+      const verdict = guardrail.failureMode === "fail_closed" ? "fail" : "pass";
+
+      result = {
+        guardrailId: guardrail.id,
+        guardrailName: guardrail.name,
+        verdict,
+        confidence: null,
+        reasoning: null,
+        categories: null,
+        latencyMs,
+        failureMode: guardrail.failureMode,
+        error: errorMsg,
+      };
+    }
+
+    results.push(result);
+
+    // Record audit event (best-effort)
+    try {
+      await recordAuditEvent(prisma, {
+        eventType: "guardrail.evaluated",
+        submissionId: input.submissionId,
+        actor: guardrail.name,
+        actorType: "guardrail",
+        payload: {
+          guardrail_id: guardrail.id,
+          verdict: result.verdict,
+          confidence: result.confidence,
+          latency_ms: result.latencyMs,
+          error: result.error,
+        },
+      });
+    } catch {
+      // Best-effort
+    }
+
+    // Short-circuit on fail_closed failure
+    if (result.verdict === "fail" && guardrail.failureMode === "fail_closed") {
+      break;
+    }
+  }
+
+  return results;
+}
+
+function validateVerdict(verdict: unknown): "pass" | "fail" | "flag" {
+  if (verdict === "pass" || verdict === "fail" || verdict === "flag") {
+    return verdict;
+  }
+  throw new Error(`Invalid verdict: ${String(verdict)}`);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { createSubmissionRouter } from "./routes/submissions.js";
 import { createReviewRouter, createReviewActionsRouter } from "./routes/reviews.js";
 import { createFeedbackRouter } from "./routes/feedback.js";
 import { createAuditRouter } from "./routes/audit.js";
+import { createGuardrailRouter } from "./routes/guardrails.js";
 import { createWebhookQueue, createWebhookWorker } from "./workers/webhook.js";
 
 const pool = new pg.Pool({ connectionString: config.databaseUrl });
@@ -38,6 +39,7 @@ app.use("/api/v1/submissions", createSubmissionRouter(prisma, webhookQueue));
 app.use("/api/v1/submissions", createReviewRouter(prisma, webhookQueue));
 app.use("/api/v1/submissions", createFeedbackRouter(prisma));
 app.use("/api/v1/audit", createAuditRouter(prisma));
+app.use("/api/v1/guardrails", createGuardrailRouter(prisma));
 
 async function start(): Promise<void> {
   const worker = createWebhookWorker(prisma, config.redisUrl);

--- a/src/routes/guardrails.test.ts
+++ b/src/routes/guardrails.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+import { createGuardrailRouter } from "./guardrails.js";
+
+const UUID = "00000000-0000-0000-0000-000000000001";
+
+function buildApp(mockPrisma: Record<string, unknown>) {
+  const prisma = mockPrisma as unknown as Parameters<typeof createGuardrailRouter>[0];
+  const app = express();
+  app.use(express.json());
+  app.use("/api/v1/guardrails", createGuardrailRouter(prisma));
+  return app;
+}
+
+const sampleGuardrail = {
+  id: UUID,
+  name: "test-guardrail",
+  endpointUrl: "https://example.com/evaluate",
+  timeoutMs: 10000,
+  failureMode: "fail_closed",
+  pipelineOrder: 1,
+  scopeChannel: null,
+  scopeContentType: null,
+  active: true,
+  createdAt: new Date("2026-01-01"),
+};
+
+describe("POST /api/v1/guardrails", () => {
+  it("creates a guardrail adapter", async () => {
+    const createFn = vi.fn().mockResolvedValue(sampleGuardrail);
+    const app = buildApp({ guardrail: { create: createFn } });
+
+    const res = await request(app).post("/api/v1/guardrails").send({
+      name: "test-guardrail",
+      endpoint_url: "https://example.com/evaluate",
+      failure_mode: "fail_closed",
+      pipeline_order: 1,
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe("test-guardrail");
+    expect(res.body.endpoint_url).toBe("https://example.com/evaluate");
+    expect(res.body.failure_mode).toBe("fail_closed");
+    expect(res.body.pipeline_order).toBe(1);
+    expect(res.body.timeout_ms).toBe(10000);
+  });
+
+  it("creates with custom timeout", async () => {
+    const createFn = vi.fn().mockResolvedValue({ ...sampleGuardrail, timeoutMs: 5000 });
+    const app = buildApp({ guardrail: { create: createFn } });
+
+    const res = await request(app).post("/api/v1/guardrails").send({
+      name: "test",
+      endpoint_url: "https://example.com/evaluate",
+      failure_mode: "fail_open",
+      pipeline_order: 1,
+      timeout_ms: 5000,
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.timeout_ms).toBe(5000);
+  });
+
+  it("returns 400 for missing name", async () => {
+    const app = buildApp({ guardrail: { create: vi.fn() } });
+
+    const res = await request(app).post("/api/v1/guardrails").send({
+      endpoint_url: "https://example.com/evaluate",
+      failure_mode: "fail_closed",
+      pipeline_order: 1,
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain("name");
+  });
+
+  it("returns 400 for missing endpoint_url", async () => {
+    const app = buildApp({ guardrail: { create: vi.fn() } });
+
+    const res = await request(app).post("/api/v1/guardrails").send({
+      name: "test",
+      failure_mode: "fail_closed",
+      pipeline_order: 1,
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain("endpoint_url");
+  });
+
+  it("returns 400 for invalid failure_mode", async () => {
+    const app = buildApp({ guardrail: { create: vi.fn() } });
+
+    const res = await request(app).post("/api/v1/guardrails").send({
+      name: "test",
+      endpoint_url: "https://example.com/evaluate",
+      failure_mode: "invalid",
+      pipeline_order: 1,
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain("failure_mode");
+  });
+
+  it("returns 400 for missing pipeline_order", async () => {
+    const app = buildApp({ guardrail: { create: vi.fn() } });
+
+    const res = await request(app).post("/api/v1/guardrails").send({
+      name: "test",
+      endpoint_url: "https://example.com/evaluate",
+      failure_mode: "fail_closed",
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain("pipeline_order");
+  });
+
+  it("returns 400 for timeout_ms exceeding max", async () => {
+    const app = buildApp({ guardrail: { create: vi.fn() } });
+
+    const res = await request(app).post("/api/v1/guardrails").send({
+      name: "test",
+      endpoint_url: "https://example.com/evaluate",
+      failure_mode: "fail_closed",
+      pipeline_order: 1,
+      timeout_ms: 50000,
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain("timeout_ms");
+  });
+});
+
+describe("GET /api/v1/guardrails", () => {
+  it("lists all guardrails", async () => {
+    const app = buildApp({
+      guardrail: { findMany: vi.fn().mockResolvedValue([sampleGuardrail]) },
+    });
+
+    const res = await request(app).get("/api/v1/guardrails");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.total).toBe(1);
+    expect(res.body.data[0].name).toBe("test-guardrail");
+  });
+});
+
+describe("GET /api/v1/guardrails/:id", () => {
+  it("returns a single guardrail", async () => {
+    const app = buildApp({
+      guardrail: { findUnique: vi.fn().mockResolvedValue(sampleGuardrail) },
+    });
+
+    const res = await request(app).get(`/api/v1/guardrails/${UUID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe("test-guardrail");
+  });
+
+  it("returns 404 for non-existent guardrail", async () => {
+    const app = buildApp({
+      guardrail: { findUnique: vi.fn().mockResolvedValue(null) },
+    });
+
+    const res = await request(app).get(`/api/v1/guardrails/${UUID}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 for invalid ID format", async () => {
+    const app = buildApp({ guardrail: { findUnique: vi.fn() } });
+
+    const res = await request(app).get("/api/v1/guardrails/not-a-uuid");
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("PUT /api/v1/guardrails/:id", () => {
+  it("updates a guardrail", async () => {
+    const updatedGuardrail = { ...sampleGuardrail, name: "updated-name" };
+    const app = buildApp({
+      guardrail: {
+        findUnique: vi.fn().mockResolvedValue(sampleGuardrail),
+        update: vi.fn().mockResolvedValue(updatedGuardrail),
+      },
+    });
+
+    const res = await request(app).put(`/api/v1/guardrails/${UUID}`).send({ name: "updated-name" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe("updated-name");
+  });
+
+  it("returns 404 for non-existent guardrail", async () => {
+    const app = buildApp({
+      guardrail: { findUnique: vi.fn().mockResolvedValue(null) },
+    });
+
+    const res = await request(app).put(`/api/v1/guardrails/${UUID}`).send({ name: "updated" });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 for invalid failure_mode", async () => {
+    const app = buildApp({
+      guardrail: { findUnique: vi.fn().mockResolvedValue(sampleGuardrail) },
+    });
+
+    const res = await request(app)
+      .put(`/api/v1/guardrails/${UUID}`)
+      .send({ failure_mode: "invalid" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain("failure_mode");
+  });
+});
+
+describe("DELETE /api/v1/guardrails/:id", () => {
+  it("soft-deletes a guardrail", async () => {
+    const updateFn = vi.fn().mockResolvedValue({ ...sampleGuardrail, active: false });
+    const app = buildApp({
+      guardrail: {
+        findUnique: vi.fn().mockResolvedValue(sampleGuardrail),
+        update: updateFn,
+      },
+    });
+
+    const res = await request(app).delete(`/api/v1/guardrails/${UUID}`);
+
+    expect(res.status).toBe(204);
+    expect(updateFn).toHaveBeenCalledWith({
+      where: { id: UUID },
+      data: { active: false },
+    });
+  });
+
+  it("returns 404 for non-existent guardrail", async () => {
+    const app = buildApp({
+      guardrail: { findUnique: vi.fn().mockResolvedValue(null) },
+    });
+
+    const res = await request(app).delete(`/api/v1/guardrails/${UUID}`);
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/routes/guardrails.ts
+++ b/src/routes/guardrails.ts
@@ -1,0 +1,237 @@
+import { Router } from "express";
+import type { PrismaClient } from "../generated/prisma/client.js";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const VALID_FAILURE_MODES = ["fail_open", "fail_closed"] as const;
+const MAX_TIMEOUT_MS = 30000;
+
+export function createGuardrailRouter(prisma: PrismaClient): Router {
+  const router = Router();
+
+  // POST /api/v1/guardrails — register a guardrail adapter
+  router.post("/", async (req, res) => {
+    const {
+      name,
+      endpoint_url,
+      timeout_ms,
+      failure_mode,
+      pipeline_order,
+      scope_channel,
+      scope_content_type,
+    } = req.body as {
+      name?: string;
+      endpoint_url?: string;
+      timeout_ms?: number;
+      failure_mode?: string;
+      pipeline_order?: number;
+      scope_channel?: string;
+      scope_content_type?: string;
+    };
+
+    if (!name || typeof name !== "string" || name.trim().length === 0) {
+      res.status(400).json({ error: "bad_request", message: "name is required" });
+      return;
+    }
+    if (!endpoint_url || typeof endpoint_url !== "string") {
+      res.status(400).json({ error: "bad_request", message: "endpoint_url is required" });
+      return;
+    }
+    if (
+      !failure_mode ||
+      !VALID_FAILURE_MODES.includes(failure_mode as (typeof VALID_FAILURE_MODES)[number])
+    ) {
+      res.status(400).json({
+        error: "bad_request",
+        message: `failure_mode must be one of: ${VALID_FAILURE_MODES.join(", ")}`,
+      });
+      return;
+    }
+    if (
+      pipeline_order === undefined ||
+      typeof pipeline_order !== "number" ||
+      !Number.isInteger(pipeline_order)
+    ) {
+      res.status(400).json({ error: "bad_request", message: "pipeline_order must be an integer" });
+      return;
+    }
+    if (
+      timeout_ms !== undefined &&
+      (typeof timeout_ms !== "number" || timeout_ms < 1 || timeout_ms > MAX_TIMEOUT_MS)
+    ) {
+      res.status(400).json({
+        error: "bad_request",
+        message: `timeout_ms must be between 1 and ${MAX_TIMEOUT_MS}`,
+      });
+      return;
+    }
+
+    const guardrail = await prisma.guardrail.create({
+      data: {
+        name: name.trim(),
+        endpointUrl: endpoint_url,
+        timeoutMs: timeout_ms ?? 10000,
+        failureMode: failure_mode as "fail_open" | "fail_closed",
+        pipelineOrder: pipeline_order,
+        scopeChannel: scope_channel ?? null,
+        scopeContentType: scope_content_type ?? null,
+      },
+    });
+
+    res.status(201).json(formatGuardrail(guardrail));
+  });
+
+  // GET /api/v1/guardrails — list all guardrails
+  router.get("/", async (_req, res) => {
+    const guardrails = await prisma.guardrail.findMany({
+      orderBy: { pipelineOrder: "asc" },
+    });
+
+    res.json({
+      data: guardrails.map(formatGuardrail),
+      total: guardrails.length,
+    });
+  });
+
+  // GET /api/v1/guardrails/:id
+  router.get("/:id", async (req, res) => {
+    const { id } = req.params;
+    if (!UUID_RE.test(id)) {
+      res.status(400).json({ error: "bad_request", message: "Invalid guardrail ID" });
+      return;
+    }
+
+    const guardrail = await prisma.guardrail.findUnique({ where: { id } });
+    if (!guardrail) {
+      res.status(404).json({ error: "not_found", message: "Guardrail not found" });
+      return;
+    }
+
+    res.json(formatGuardrail(guardrail));
+  });
+
+  // PUT /api/v1/guardrails/:id
+  router.put("/:id", async (req, res) => {
+    const { id } = req.params;
+    if (!UUID_RE.test(id)) {
+      res.status(400).json({ error: "bad_request", message: "Invalid guardrail ID" });
+      return;
+    }
+
+    const existing = await prisma.guardrail.findUnique({ where: { id } });
+    if (!existing) {
+      res.status(404).json({ error: "not_found", message: "Guardrail not found" });
+      return;
+    }
+
+    const {
+      name,
+      endpoint_url,
+      timeout_ms,
+      failure_mode,
+      pipeline_order,
+      scope_channel,
+      scope_content_type,
+    } = req.body as {
+      name?: string;
+      endpoint_url?: string;
+      timeout_ms?: number;
+      failure_mode?: string;
+      pipeline_order?: number;
+      scope_channel?: string;
+      scope_content_type?: string;
+    };
+
+    if (
+      failure_mode &&
+      !VALID_FAILURE_MODES.includes(failure_mode as (typeof VALID_FAILURE_MODES)[number])
+    ) {
+      res.status(400).json({
+        error: "bad_request",
+        message: `failure_mode must be one of: ${VALID_FAILURE_MODES.join(", ")}`,
+      });
+      return;
+    }
+    if (
+      timeout_ms !== undefined &&
+      (typeof timeout_ms !== "number" || timeout_ms < 1 || timeout_ms > MAX_TIMEOUT_MS)
+    ) {
+      res.status(400).json({
+        error: "bad_request",
+        message: `timeout_ms must be between 1 and ${MAX_TIMEOUT_MS}`,
+      });
+      return;
+    }
+    if (
+      pipeline_order !== undefined &&
+      (typeof pipeline_order !== "number" || !Number.isInteger(pipeline_order))
+    ) {
+      res.status(400).json({ error: "bad_request", message: "pipeline_order must be an integer" });
+      return;
+    }
+
+    const updated = await prisma.guardrail.update({
+      where: { id },
+      data: {
+        ...(name && { name: name.trim() }),
+        ...(endpoint_url && { endpointUrl: endpoint_url }),
+        ...(timeout_ms !== undefined && { timeoutMs: timeout_ms }),
+        ...(failure_mode && { failureMode: failure_mode as "fail_open" | "fail_closed" }),
+        ...(pipeline_order !== undefined && { pipelineOrder: pipeline_order }),
+        ...(scope_channel !== undefined && { scopeChannel: scope_channel || null }),
+        ...(scope_content_type !== undefined && { scopeContentType: scope_content_type || null }),
+      },
+    });
+
+    res.json(formatGuardrail(updated));
+  });
+
+  // DELETE /api/v1/guardrails/:id — soft delete
+  router.delete("/:id", async (req, res) => {
+    const { id } = req.params;
+    if (!UUID_RE.test(id)) {
+      res.status(400).json({ error: "bad_request", message: "Invalid guardrail ID" });
+      return;
+    }
+
+    const existing = await prisma.guardrail.findUnique({ where: { id } });
+    if (!existing) {
+      res.status(404).json({ error: "not_found", message: "Guardrail not found" });
+      return;
+    }
+
+    await prisma.guardrail.update({
+      where: { id },
+      data: { active: false },
+    });
+
+    res.status(204).send();
+  });
+
+  return router;
+}
+
+function formatGuardrail(g: {
+  id: string;
+  name: string;
+  endpointUrl: string;
+  timeoutMs: number;
+  failureMode: string;
+  pipelineOrder: number;
+  scopeChannel: string | null;
+  scopeContentType: string | null;
+  active: boolean;
+  createdAt: Date;
+}) {
+  return {
+    id: g.id,
+    name: g.name,
+    endpoint_url: g.endpointUrl,
+    timeout_ms: g.timeoutMs,
+    failure_mode: g.failureMode,
+    pipeline_order: g.pipelineOrder,
+    scope_channel: g.scopeChannel,
+    scope_content_type: g.scopeContentType,
+    active: g.active,
+    created_at: g.createdAt,
+  };
+}


### PR DESCRIPTION
Closes #10

## Summary

- **Guardrail CRUD API** — POST/GET/PUT/DELETE `/api/v1/guardrails` for registering external AI safety adapters
- **Evaluation pipeline** (`src/engine/guardrail.ts`) — calls adapters in `pipeline_order`, supports `fail_open`/`fail_closed` failure modes, configurable timeouts (max 30s)
- **Short-circuit logic** — `fail_closed` adapter returning `fail` stops the pipeline immediately
- **Fail-safe behavior** — adapter errors/timeouts apply the configured failure mode
- **Channel/content-type scoping** — guardrails only evaluate matching submissions
- **Audit integration** — each guardrail evaluation generates an audit event with `actor_type: guardrail`

## Files changed

| File | Change |
|------|--------|
| `src/engine/guardrail.ts` | New: evaluation pipeline with timeout, failure modes, scoping |
| `src/engine/guardrail.test.ts` | New: 12 tests with MSW mock adapters |
| `src/routes/guardrails.ts` | New: CRUD endpoints with validation |
| `src/routes/guardrails.test.ts` | New: 16 tests for all CRUD operations |
| `src/index.ts` | Wire guardrail router |

## Test evidence

```
 Test Files  14 passed (14)
      Tests  179 passed (179)
   Duration  3.07s
```

TypeScript: ✅ no errors
ESLint: ✅ clean
Prettier: ✅ formatted

## Test plan

- [x] Pipeline: empty guardrails returns empty results
- [x] Pipeline: pass/fail/flag verdicts handled correctly
- [x] Pipeline: multiple guardrails evaluated in order
- [x] Pipeline: fail_closed short-circuits on fail
- [x] Pipeline: fail_open continues on fail
- [x] Pipeline: adapter error applies fail_closed → fail
- [x] Pipeline: adapter error applies fail_open → pass
- [x] Pipeline: timeout triggers failure mode
- [x] Pipeline: audit events recorded per evaluation
- [x] Pipeline: correct payload sent to adapter
- [x] CRUD: create with all fields
- [x] CRUD: create with custom timeout
- [x] CRUD: validation for name, endpoint_url, failure_mode, pipeline_order, timeout_ms
- [x] CRUD: list, get by ID, update, soft-delete
- [x] CRUD: 404 for non-existent, 400 for invalid ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)